### PR TITLE
Bump version.io.quarkiverse.embedded.postgresql to 0.2.3 (#2011)

### DIFF
--- a/serverless-workflow-examples/serverless-workflow-timeouts-showcase-embedded/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-timeouts-showcase-embedded/pom.xml
@@ -51,7 +51,7 @@
     <version.org.webjars.bootstrap>5.1.3</version.org.webjars.bootstrap>
     <version.org.webjars.jquery>3.6.0</version.org.webjars.jquery>
     <!-- Embedded postgresql version should be updated manually when an update is occurring -->
-    <version.io.quarkiverse.embedded.postgresql>0.2.2</version.io.quarkiverse.embedded.postgresql>
+    <version.io.quarkiverse.embedded.postgresql>0.2.3</version.io.quarkiverse.embedded.postgresql>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
Backported from https://github.com/apache/incubator-kie-kogito-examples/pull/2011