### PR TITLE
NO_ISSUE: Remove serverless-workflow-fault-tolerance from productized modules

### DIFF
--- a/productized/modules
+++ b/productized/modules
@@ -1,2 +1,2 @@
 pom.xml;kogito-java-examples,kogito-quarkus-examples,kogito-springboot-examples
-serverless-workflow-examples/pom.xml;serverless-workflow-camel-routes,serverless-workflow-data-index-persistence-addon-quarkus,serverless-workflow-dmn-quarkus,serverless-workflow-events-quarkus,serverless-workflow-functions-events-quarkus,serverless-workflow-oauth2-orchestration-quarkus,serverless-workflow-python-quarkus
+serverless-workflow-examples/pom.xml;serverless-workflow-camel-routes,serverless-workflow-data-index-persistence-addon-quarkus,serverless-workflow-dmn-quarkus,serverless-workflow-events-quarkus,serverless-workflow-functions-events-quarkus,serverless-workflow-oauth2-orchestration-quarkus,serverless-workflow-python-quarkus,serverless-workflow-fault-tolerance


### PR DESCRIPTION
The build in nightly prod fails on this example, it is new, removing it until we can fix it.

https://issues.redhat.com/browse/BAQE-3160