### PR TITLE
[SRVLOGIC-963] Changes for snapshots publishing.

### DIFF
--- a/gradle-examples/kogito-quarkus-gradle-examples/dmn-quarkus-gradle/pom.xml
+++ b/gradle-examples/kogito-quarkus-gradle-examples/dmn-quarkus-gradle/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-gradle-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>dmn-quarkus-gradle</artifactId>

--- a/gradle-examples/kogito-quarkus-gradle-examples/dmn-quarkus-gradle/pom.xml
+++ b/gradle-examples/kogito-quarkus-gradle-examples/dmn-quarkus-gradle/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-gradle-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>dmn-quarkus-gradle</artifactId>

--- a/gradle-examples/kogito-quarkus-gradle-examples/pom.xml
+++ b/gradle-examples/kogito-quarkus-gradle-examples/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>gradle-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <packaging>pom</packaging>
 

--- a/gradle-examples/kogito-quarkus-gradle-examples/pom.xml
+++ b/gradle-examples/kogito-quarkus-gradle-examples/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>gradle-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <packaging>pom</packaging>
 

--- a/gradle-examples/kogito-quarkus-gradle-examples/process-decisions-rules-quarkus-gradle/pom.xml
+++ b/gradle-examples/kogito-quarkus-gradle-examples/process-decisions-rules-quarkus-gradle/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.kie.kogito.examples</groupId>
         <artifactId>kogito-quarkus-gradle-examples</artifactId>
-        <version>111-SNAPSHOIT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>process-decisions-rules-quarkus-gradle</artifactId>

--- a/gradle-examples/kogito-quarkus-gradle-examples/process-decisions-rules-quarkus-gradle/pom.xml
+++ b/gradle-examples/kogito-quarkus-gradle-examples/process-decisions-rules-quarkus-gradle/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.kie.kogito.examples</groupId>
         <artifactId>kogito-quarkus-gradle-examples</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOIT</version>
     </parent>
 
     <artifactId>process-decisions-rules-quarkus-gradle</artifactId>

--- a/gradle-examples/kogito-springboot-gradle-examples/dmn-springboot-gradle/pom.xml
+++ b/gradle-examples/kogito-springboot-gradle-examples/dmn-springboot-gradle/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-gradle-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>dmn-springboot-gradle</artifactId>

--- a/gradle-examples/kogito-springboot-gradle-examples/dmn-springboot-gradle/pom.xml
+++ b/gradle-examples/kogito-springboot-gradle-examples/dmn-springboot-gradle/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-gradle-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>dmn-springboot-gradle</artifactId>

--- a/gradle-examples/kogito-springboot-gradle-examples/pom.xml
+++ b/gradle-examples/kogito-springboot-gradle-examples/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>gradle-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <packaging>pom</packaging>
 

--- a/gradle-examples/kogito-springboot-gradle-examples/pom.xml
+++ b/gradle-examples/kogito-springboot-gradle-examples/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>gradle-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <packaging>pom</packaging>
 

--- a/gradle-examples/kogito-springboot-gradle-examples/process-decisions-rules-springboot-gradle/pom.xml
+++ b/gradle-examples/kogito-springboot-gradle-examples/process-decisions-rules-springboot-gradle/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-gradle-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>process-decisions-rules-springboot-gradle</artifactId>

--- a/gradle-examples/kogito-springboot-gradle-examples/process-decisions-rules-springboot-gradle/pom.xml
+++ b/gradle-examples/kogito-springboot-gradle-examples/process-decisions-rules-springboot-gradle/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-gradle-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-decisions-rules-springboot-gradle</artifactId>

--- a/gradle-examples/pom.xml
+++ b/gradle-examples/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>gradle-examples</artifactId>
   <packaging>pom</packaging>

--- a/gradle-examples/pom.xml
+++ b/gradle-examples/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>gradle-examples</artifactId>
   <packaging>pom</packaging>

--- a/kogito-java-examples/dmn-embedded-mode-example/pom.xml
+++ b/kogito-java-examples/dmn-embedded-mode-example/pom.xml
@@ -24,7 +24,7 @@
     <groupId>org.kie.kogito.decisions.embedded</groupId>
     <artifactId>dmn-embedded-mode-example</artifactId>
     <name>Kogito Example :: DMN Embedded Mode</name>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <packaging>kjar</packaging>
 
     <properties>
@@ -33,11 +33,11 @@
         <maven.compiler.target>17</maven.compiler.target>
         <exec.mainClass>org.kie.kogito.decisions.embedded.DecisionsEmbeddedModeExample</exec.mainClass>
 
-        <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-        <version.org.drools>111-SNAPSHOIT</version.org.drools>
-        <version.org.drools>111-SNAPSHOIT</version.org.drools>
-        <version.kogito.bom>111-SNAPSHOIT</version.kogito.bom>
-        <version.org.kie>111-SNAPSHOIT</version.org.kie>
+        <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+        <version.org.drools>111-SNAPSHOT</version.org.drools>
+        <version.org.drools>111-SNAPSHOT</version.org.drools>
+        <version.kogito.bom>111-SNAPSHOT</version.kogito.bom>
+        <version.org.kie>111-SNAPSHOT</version.org.kie>
 
         <version.org.slf4j>2.0.13</version.org.slf4j>
     </properties>

--- a/kogito-java-examples/dmn-embedded-mode-example/pom.xml
+++ b/kogito-java-examples/dmn-embedded-mode-example/pom.xml
@@ -24,7 +24,7 @@
     <groupId>org.kie.kogito.decisions.embedded</groupId>
     <artifactId>dmn-embedded-mode-example</artifactId>
     <name>Kogito Example :: DMN Embedded Mode</name>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <packaging>kjar</packaging>
 
     <properties>
@@ -33,11 +33,11 @@
         <maven.compiler.target>17</maven.compiler.target>
         <exec.mainClass>org.kie.kogito.decisions.embedded.DecisionsEmbeddedModeExample</exec.mainClass>
 
-        <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-        <version.org.drools>999-SNAPSHOT</version.org.drools>
-        <version.org.drools>999-SNAPSHOT</version.org.drools>
-        <version.kogito.bom>999-SNAPSHOT</version.kogito.bom>
-        <version.org.kie>999-SNAPSHOT</version.org.kie>
+        <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+        <version.org.drools>111-SNAPSHOIT</version.org.drools>
+        <version.org.drools>111-SNAPSHOIT</version.org.drools>
+        <version.kogito.bom>111-SNAPSHOIT</version.kogito.bom>
+        <version.org.kie>111-SNAPSHOIT</version.org.kie>
 
         <version.org.slf4j>2.0.13</version.org.slf4j>
     </properties>

--- a/kogito-java-examples/pom.xml
+++ b/kogito-java-examples/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-java-examples</artifactId>

--- a/kogito-java-examples/pom.xml
+++ b/kogito-java-examples/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>kogito-java-examples</artifactId>

--- a/kogito-java-examples/rules-embedded-mode-example/pom.xml
+++ b/kogito-java-examples/rules-embedded-mode-example/pom.xml
@@ -24,7 +24,7 @@
     <groupId>org.kie.kogito.rules.embedded</groupId>
     <artifactId>rules-embedded-mode-example</artifactId>
     <name>Kogito Example :: Rule Embedded Mode</name>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <packaging>kjar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -32,11 +32,11 @@
         <maven.compiler.target>17</maven.compiler.target>
         <exec.mainClass>org.kie.kogito.rules.embedded.RulesEmbeddedModeExample</exec.mainClass>
 
-        <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-        <version.org.drools>999-SNAPSHOT</version.org.drools>
-        <version.org.drools>999-SNAPSHOT</version.org.drools>
-        <version.kogito.bom>999-SNAPSHOT</version.kogito.bom>
-        <version.org.kie>999-SNAPSHOT</version.org.kie>
+        <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+        <version.org.drools>111-SNAPSHOIT</version.org.drools>
+        <version.org.drools>111-SNAPSHOIT</version.org.drools>
+        <version.kogito.bom>111-SNAPSHOIT</version.kogito.bom>
+        <version.org.kie>111-SNAPSHOIT</version.org.kie>
 
         <version.org.slf4j>2.0.13</version.org.slf4j>
     </properties>

--- a/kogito-java-examples/rules-embedded-mode-example/pom.xml
+++ b/kogito-java-examples/rules-embedded-mode-example/pom.xml
@@ -24,7 +24,7 @@
     <groupId>org.kie.kogito.rules.embedded</groupId>
     <artifactId>rules-embedded-mode-example</artifactId>
     <name>Kogito Example :: Rule Embedded Mode</name>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <packaging>kjar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -32,11 +32,11 @@
         <maven.compiler.target>17</maven.compiler.target>
         <exec.mainClass>org.kie.kogito.rules.embedded.RulesEmbeddedModeExample</exec.mainClass>
 
-        <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-        <version.org.drools>111-SNAPSHOIT</version.org.drools>
-        <version.org.drools>111-SNAPSHOIT</version.org.drools>
-        <version.kogito.bom>111-SNAPSHOIT</version.kogito.bom>
-        <version.org.kie>111-SNAPSHOIT</version.org.kie>
+        <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+        <version.org.drools>111-SNAPSHOT</version.org.drools>
+        <version.org.drools>111-SNAPSHOT</version.org.drools>
+        <version.kogito.bom>111-SNAPSHOT</version.kogito.bom>
+        <version.org.kie>111-SNAPSHOT</version.org.kie>
 
         <version.org.slf4j>2.0.13</version.org.slf4j>
     </properties>

--- a/kogito-quarkus-examples/decisiontable-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/decisiontable-quarkus-example/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>decisiontable-quarkus-example</artifactId>
   <name>Kogito Example :: Decision Table - Quarkus</name>
@@ -36,9 +36,9 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <version.org.drools>999-SNAPSHOT</version.org.drools>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <version.org.drools>111-SNAPSHOIT</version.org.drools>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/decisiontable-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/decisiontable-quarkus-example/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>decisiontable-quarkus-example</artifactId>
   <name>Kogito Example :: Decision Table - Quarkus</name>
@@ -36,9 +36,9 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <version.org.drools>111-SNAPSHOIT</version.org.drools>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <version.org.drools>111-SNAPSHOT</version.org.drools>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/dmn-15-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/dmn-15-quarkus-example/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>dmn-15-quarkus-example</artifactId>
@@ -18,8 +18,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
     <dependency-plugin.version>3.6.1</dependency-plugin.version>
   </properties>
   <dependencyManagement>

--- a/kogito-quarkus-examples/dmn-15-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/dmn-15-quarkus-example/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>dmn-15-quarkus-example</artifactId>
@@ -18,8 +18,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
     <dependency-plugin.version>3.6.1</dependency-plugin.version>
   </properties>
   <dependencyManagement>

--- a/kogito-quarkus-examples/dmn-drools-quarkus-metrics/pom.xml
+++ b/kogito-quarkus-examples/dmn-drools-quarkus-metrics/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-drools-quarkus-metrics</artifactId>
   <name>Kogito Example :: DMN Metrics Quarkus</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/dmn-drools-quarkus-metrics/pom.xml
+++ b/kogito-quarkus-examples/dmn-drools-quarkus-metrics/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>dmn-drools-quarkus-metrics</artifactId>
   <name>Kogito Example :: DMN Metrics Quarkus</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/dmn-event-driven-quarkus/pom.xml
+++ b/kogito-quarkus-examples/dmn-event-driven-quarkus/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>dmn-event-driven-quarkus</artifactId>
   <name>Kogito Example :: DMN Event-Driven :: Quarkus</name>
@@ -38,8 +38,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/dmn-event-driven-quarkus/pom.xml
+++ b/kogito-quarkus-examples/dmn-event-driven-quarkus/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-event-driven-quarkus</artifactId>
   <name>Kogito Example :: DMN Event-Driven :: Quarkus</name>
@@ -38,8 +38,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/dmn-incubation-api-quarkus/pom.xml
+++ b/kogito-quarkus-examples/dmn-incubation-api-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>dmn-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: DMN Incubation API With Quarkus</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/dmn-incubation-api-quarkus/pom.xml
+++ b/kogito-quarkus-examples/dmn-incubation-api-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: DMN Incubation API With Quarkus</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/dmn-knative-quickstart-quarkus/pom.xml
+++ b/kogito-quarkus-examples/dmn-knative-quickstart-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>dmn-knative-quickstart-quarkus</artifactId>
@@ -40,8 +40,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/dmn-knative-quickstart-quarkus/pom.xml
+++ b/kogito-quarkus-examples/dmn-knative-quickstart-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>dmn-knative-quickstart-quarkus</artifactId>
@@ -40,8 +40,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/dmn-listener-dtable/pom.xml
+++ b/kogito-quarkus-examples/dmn-listener-dtable/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-listener-dtable</artifactId>
   <name>Kogito Example :: DMN Decision Table listener - Quarkus</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/dmn-listener-dtable/pom.xml
+++ b/kogito-quarkus-examples/dmn-listener-dtable/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>dmn-listener-dtable</artifactId>
   <name>Kogito Example :: DMN Decision Table listener - Quarkus</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/dmn-listener-quarkus/pom.xml
+++ b/kogito-quarkus-examples/dmn-listener-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>dmn-listener-quarkus</artifactId>
   <name>Kogito Example :: DMN with listeners - Quarkus</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/dmn-listener-quarkus/pom.xml
+++ b/kogito-quarkus-examples/dmn-listener-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-listener-quarkus</artifactId>
   <name>Kogito Example :: DMN with listeners - Quarkus</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/dmn-multiple-models-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/dmn-multiple-models-quarkus-example/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-multiple-models-quarkus-example</artifactId>
   <name>Kogito Example :: DMN :: Multiple Models</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/dmn-multiple-models-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/dmn-multiple-models-quarkus-example/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>dmn-multiple-models-quarkus-example</artifactId>
   <name>Kogito Example :: DMN :: Multiple Models</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/dmn-pmml-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/dmn-pmml-quarkus-example/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>dmn-pmml-quarkus-example</artifactId>
   <name>Kogito Example :: DMN :: PMML - QUARKUS</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
 
   <dependencyManagement>

--- a/kogito-quarkus-examples/dmn-pmml-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/dmn-pmml-quarkus-example/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-pmml-quarkus-example</artifactId>
   <name>Kogito Example :: DMN :: PMML - QUARKUS</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
 
   <dependencyManagement>

--- a/kogito-quarkus-examples/dmn-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/dmn-quarkus-example/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-quarkus-example</artifactId>
   <name>Kogito Example :: DMN</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/dmn-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/dmn-quarkus-example/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>dmn-quarkus-example</artifactId>
   <name>Kogito Example :: DMN</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/dmn-resource-jar-quarkus-example/dmn-quarkus-consumer-example/pom.xml
+++ b/kogito-quarkus-examples/dmn-resource-jar-quarkus-example/dmn-quarkus-consumer-example/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>dmn-resource-jar-quarkus-example</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>dmn-quarkus-consumer-example</artifactId>
@@ -18,8 +18,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
     <dependency-plugin.version>3.6.1</dependency-plugin.version>
   </properties>
   <dependencyManagement>

--- a/kogito-quarkus-examples/dmn-resource-jar-quarkus-example/dmn-quarkus-consumer-example/pom.xml
+++ b/kogito-quarkus-examples/dmn-resource-jar-quarkus-example/dmn-quarkus-consumer-example/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>dmn-resource-jar-quarkus-example</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>dmn-quarkus-consumer-example</artifactId>
@@ -18,8 +18,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
     <dependency-plugin.version>3.6.1</dependency-plugin.version>
   </properties>
   <dependencyManagement>

--- a/kogito-quarkus-examples/dmn-resource-jar-quarkus-example/dmn-quarkus-resource-jar/pom.xml
+++ b/kogito-quarkus-examples/dmn-resource-jar-quarkus-example/dmn-quarkus-resource-jar/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>dmn-resource-jar-quarkus-example</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>dmn-quarkus-resource-jar</artifactId>

--- a/kogito-quarkus-examples/dmn-resource-jar-quarkus-example/dmn-quarkus-resource-jar/pom.xml
+++ b/kogito-quarkus-examples/dmn-resource-jar-quarkus-example/dmn-quarkus-resource-jar/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>dmn-resource-jar-quarkus-example</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>dmn-quarkus-resource-jar</artifactId>

--- a/kogito-quarkus-examples/dmn-resource-jar-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/dmn-resource-jar-quarkus-example/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-resource-jar-quarkus-example</artifactId>
   <name>Kogito Example :: DMN :: Resource jar providing model</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <packaging>pom</packaging>
   <modules>

--- a/kogito-quarkus-examples/dmn-resource-jar-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/dmn-resource-jar-quarkus-example/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>dmn-resource-jar-quarkus-example</artifactId>
   <name>Kogito Example :: DMN :: Resource jar providing model</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <packaging>pom</packaging>
   <modules>

--- a/kogito-quarkus-examples/dmn-tracing-quarkus/pom.xml
+++ b/kogito-quarkus-examples/dmn-tracing-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-tracing-quarkus</artifactId>
   <name>Kogito Example :: DMN Tracing - Quarkus</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/dmn-tracing-quarkus/pom.xml
+++ b/kogito-quarkus-examples/dmn-tracing-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>dmn-tracing-quarkus</artifactId>
   <name>Kogito Example :: DMN Tracing - Quarkus</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/flexible-process-quarkus/pom.xml
+++ b/kogito-quarkus-examples/flexible-process-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>flexible-process-quarkus</artifactId>
   <name>Kogito Example :: Flexible Process - Quarkus</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/flexible-process-quarkus/pom.xml
+++ b/kogito-quarkus-examples/flexible-process-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>flexible-process-quarkus</artifactId>
   <name>Kogito Example :: Flexible Process - Quarkus</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/kogito-travel-agency/basic/pom.xml
+++ b/kogito-quarkus-examples/kogito-travel-agency/basic/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-travel-agency-example</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>kogito-travel-agency-example-basic</artifactId>
   <name>Kogito Example :: Travel Agency :: Basic</name>
@@ -38,9 +38,9 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <version.org.drools>999-SNAPSHOT</version.org.drools>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <version.org.drools>111-SNAPSHOIT</version.org.drools>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/kogito-travel-agency/basic/pom.xml
+++ b/kogito-quarkus-examples/kogito-travel-agency/basic/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-travel-agency-example</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-travel-agency-example-basic</artifactId>
   <name>Kogito Example :: Travel Agency :: Basic</name>
@@ -38,9 +38,9 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <version.org.drools>111-SNAPSHOIT</version.org.drools>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <version.org.drools>111-SNAPSHOT</version.org.drools>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/kogito-travel-agency/extended/pom.xml
+++ b/kogito-quarkus-examples/kogito-travel-agency/extended/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-travel-agency-example</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-travel-agency-example-extended</artifactId>
   <packaging>pom</packaging>

--- a/kogito-quarkus-examples/kogito-travel-agency/extended/pom.xml
+++ b/kogito-quarkus-examples/kogito-travel-agency/extended/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-travel-agency-example</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>kogito-travel-agency-example-extended</artifactId>
   <packaging>pom</packaging>

--- a/kogito-quarkus-examples/kogito-travel-agency/extended/travels/pom.xml
+++ b/kogito-quarkus-examples/kogito-travel-agency/extended/travels/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-travel-agency-example-extended</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>travels</artifactId>
   <name>Kogito Example :: Travel Agency :: Travels</name>
@@ -36,9 +36,9 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <version.org.drools>999-SNAPSHOT</version.org.drools>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <version.org.drools>111-SNAPSHOIT</version.org.drools>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/kogito-travel-agency/extended/travels/pom.xml
+++ b/kogito-quarkus-examples/kogito-travel-agency/extended/travels/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-travel-agency-example-extended</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>travels</artifactId>
   <name>Kogito Example :: Travel Agency :: Travels</name>
@@ -36,9 +36,9 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <version.org.drools>111-SNAPSHOIT</version.org.drools>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <version.org.drools>111-SNAPSHOT</version.org.drools>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/kogito-travel-agency/extended/visas/pom.xml
+++ b/kogito-quarkus-examples/kogito-travel-agency/extended/visas/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-travel-agency-example-extended</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>visas</artifactId>
   <name>Kogito Example :: Travel Agency :: Visas</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/kogito-travel-agency/extended/visas/pom.xml
+++ b/kogito-quarkus-examples/kogito-travel-agency/extended/visas/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-travel-agency-example-extended</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>visas</artifactId>
   <name>Kogito Example :: Travel Agency :: Visas</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/kogito-travel-agency/pom.xml
+++ b/kogito-quarkus-examples/kogito-travel-agency/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-travel-agency-example</artifactId>
   <packaging>pom</packaging>

--- a/kogito-quarkus-examples/kogito-travel-agency/pom.xml
+++ b/kogito-quarkus-examples/kogito-travel-agency/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>kogito-travel-agency-example</artifactId>
   <packaging>pom</packaging>

--- a/kogito-quarkus-examples/onboarding-example/hr/pom.xml
+++ b/kogito-quarkus-examples/onboarding-example/hr/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>onboarding-example</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>hr</artifactId>
   <name>Kogito Example :: Onboarding Example :: HR with Drools</name>

--- a/kogito-quarkus-examples/onboarding-example/hr/pom.xml
+++ b/kogito-quarkus-examples/onboarding-example/hr/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>onboarding-example</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>hr</artifactId>
   <name>Kogito Example :: Onboarding Example :: HR with Drools</name>

--- a/kogito-quarkus-examples/onboarding-example/onboarding-quarkus/pom.xml
+++ b/kogito-quarkus-examples/onboarding-example/onboarding-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>onboarding-example</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>onboarding-quarkus</artifactId>
   <name>Kogito Example :: Onboarding Example :: Onboarding with Business Process Quarkus</name>

--- a/kogito-quarkus-examples/onboarding-example/onboarding-quarkus/pom.xml
+++ b/kogito-quarkus-examples/onboarding-example/onboarding-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>onboarding-example</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>onboarding-quarkus</artifactId>
   <name>Kogito Example :: Onboarding Example :: Onboarding with Business Process Quarkus</name>

--- a/kogito-quarkus-examples/onboarding-example/payroll/pom.xml
+++ b/kogito-quarkus-examples/onboarding-example/payroll/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>onboarding-example</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>payroll</artifactId>
   <name>Kogito Example :: Onboarding Example :: Payroll with DMN</name>

--- a/kogito-quarkus-examples/onboarding-example/payroll/pom.xml
+++ b/kogito-quarkus-examples/onboarding-example/payroll/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>onboarding-example</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>payroll</artifactId>
   <name>Kogito Example :: Onboarding Example :: Payroll with DMN</name>

--- a/kogito-quarkus-examples/onboarding-example/pom.xml
+++ b/kogito-quarkus-examples/onboarding-example/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>onboarding-example</artifactId>
   <packaging>pom</packaging>
@@ -43,8 +43,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/onboarding-example/pom.xml
+++ b/kogito-quarkus-examples/onboarding-example/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>onboarding-example</artifactId>
   <packaging>pom</packaging>
@@ -43,8 +43,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/pmml-event-driven-quarkus/pom.xml
+++ b/kogito-quarkus-examples/pmml-event-driven-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>pmml-event-driven-quarkus</artifactId>
   <name>Kogito Example :: PMML Event-Driven - Quarkus</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
 
   <dependencyManagement>

--- a/kogito-quarkus-examples/pmml-event-driven-quarkus/pom.xml
+++ b/kogito-quarkus-examples/pmml-event-driven-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>pmml-event-driven-quarkus</artifactId>
   <name>Kogito Example :: PMML Event-Driven - Quarkus</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
 
   <dependencyManagement>

--- a/kogito-quarkus-examples/pmml-incubation-api-quarkus/pom.xml
+++ b/kogito-quarkus-examples/pmml-incubation-api-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>pmml-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: PMML Incubation API With Quarkus</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/pmml-incubation-api-quarkus/pom.xml
+++ b/kogito-quarkus-examples/pmml-incubation-api-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>pmml-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: PMML Incubation API With Quarkus</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/pmml-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/pmml-quarkus-example/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>pmml-quarkus-example</artifactId>
   <name>Kogito Example :: PMML - Quarkus</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/pmml-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/pmml-quarkus-example/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>pmml-quarkus-example</artifactId>
   <name>Kogito Example :: PMML - Quarkus</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/pom.xml
+++ b/kogito-quarkus-examples/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-quarkus-examples</artifactId>

--- a/kogito-quarkus-examples/pom.xml
+++ b/kogito-quarkus-examples/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>kogito-quarkus-examples</artifactId>

--- a/kogito-quarkus-examples/process-business-calendar-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/process-business-calendar-quarkus-example/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.kie.kogito.examples</groupId>
         <artifactId>kogito-quarkus-examples</artifactId>
-        <version>111-SNAPSHOIT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     
     <artifactId>process-business-calendar-quarkus-example</artifactId>
@@ -40,8 +40,8 @@
         <quarkus.platform.version>3.27.3</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-        <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+        <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+        <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
     </properties>
     
     <dependencyManagement>

--- a/kogito-quarkus-examples/process-business-calendar-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/process-business-calendar-quarkus-example/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.kie.kogito.examples</groupId>
         <artifactId>kogito-quarkus-examples</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOIT</version>
     </parent>
     
     <artifactId>process-business-calendar-quarkus-example</artifactId>
@@ -40,8 +40,8 @@
         <quarkus.platform.version>3.27.3</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-        <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+        <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+        <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
     </properties>
     
     <dependencyManagement>

--- a/kogito-quarkus-examples/process-business-rules-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-business-rules-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>process-business-rules-quarkus</artifactId>
   <name>Kogito Example :: Process Business Rules Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-business-rules-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-business-rules-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>process-business-rules-quarkus</artifactId>
   <name>Kogito Example :: Process Business Rules Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-decisions-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-decisions-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>process-decisions-quarkus</artifactId>
   <name>Kogito Example :: Process :: Decisions :: Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-decisions-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-decisions-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>process-decisions-quarkus</artifactId>
   <name>Kogito Example :: Process :: Decisions :: Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-decisions-rest-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-decisions-rest-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>process-decisions-rest-quarkus</artifactId>
   <name>Kogito Example :: Process :: Decisions :: REST Quarkus</name>
@@ -38,8 +38,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-decisions-rest-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-decisions-rest-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>process-decisions-rest-quarkus</artifactId>
   <name>Kogito Example :: Process :: Decisions :: REST Quarkus</name>
@@ -38,8 +38,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-decisions-rules-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-decisions-rules-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>process-decisions-rules-quarkus</artifactId>
   <name>Kogito Example :: Process :: Decisions :: Rules :: Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-decisions-rules-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-decisions-rules-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>process-decisions-rules-quarkus</artifactId>
   <name>Kogito Example :: Process :: Decisions :: Rules :: Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-error-handling/pom.xml
+++ b/kogito-quarkus-examples/process-error-handling/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>process-error-handling</artifactId>
   <name>Kogito Example :: Process Scripts With Quarkus</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-error-handling/pom.xml
+++ b/kogito-quarkus-examples/process-error-handling/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>process-error-handling</artifactId>
   <name>Kogito Example :: Process Scripts With Quarkus</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-incubation-api-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-incubation-api-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>process-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: Process Incubation API With Quarkus</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-incubation-api-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-incubation-api-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>process-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: Process Incubation API With Quarkus</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-infinispan-persistence-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-infinispan-persistence-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>process-infinispan-persistence-quarkus</artifactId>
   <name>Kogito Example :: Process Infinispan Persistence Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-infinispan-persistence-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-infinispan-persistence-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>process-infinispan-persistence-quarkus</artifactId>
   <name>Kogito Example :: Process Infinispan Persistence Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-instance-migration-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-instance-migration-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>process-instance-migration-quarkus</artifactId>
   <name>Kogito Example :: Process Instance Migration Quarkus</name>
@@ -38,7 +38,7 @@
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito-apps.bom.artifact-id>kogito-apps-bom</kogito-apps.bom.artifact-id>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-instance-migration-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-instance-migration-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>process-instance-migration-quarkus</artifactId>
   <name>Kogito Example :: Process Instance Migration Quarkus</name>
@@ -38,7 +38,7 @@
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito-apps.bom.artifact-id>kogito-apps-bom</kogito-apps.bom.artifact-id>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-kafka-avro-multi-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-kafka-avro-multi-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>process-kafka-avro-multi-quarkus</artifactId>
   <name>Kogito Example :: Process with Kafka and Quarkus, multiple channels, avro serialization</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-kafka-avro-multi-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-kafka-avro-multi-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>process-kafka-avro-multi-quarkus</artifactId>
   <name>Kogito Example :: Process with Kafka and Quarkus, multiple channels, avro serialization</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-kafka-multi-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-kafka-multi-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>process-kafka-multi-quarkus</artifactId>
   <name>Kogito Example :: Process with Kafka and Quarkus, multiple channels</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-kafka-multi-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-kafka-multi-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>process-kafka-multi-quarkus</artifactId>
   <name>Kogito Example :: Process with Kafka and Quarkus, multiple channels</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-kafka-persistence-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-kafka-persistence-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -39,8 +39,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-kafka-persistence-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-kafka-persistence-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -39,8 +39,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-kafka-quickstart-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-kafka-quickstart-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>process-kafka-quickstart-quarkus</artifactId>
   <name>Kogito Example :: Process with Kafka and Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-kafka-quickstart-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-kafka-quickstart-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>process-kafka-quickstart-quarkus</artifactId>
   <name>Kogito Example :: Process with Kafka and Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-knative-quickstart-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-knative-quickstart-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>process-knative-quickstart-quarkus</artifactId>
   <name>Kogito Example :: Process with Knative Eventing and Quarkus</name>
@@ -38,8 +38,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-knative-quickstart-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-knative-quickstart-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>process-knative-quickstart-quarkus</artifactId>
   <name>Kogito Example :: Process with Knative Eventing and Quarkus</name>
@@ -38,8 +38,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-mongodb-persistence-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-mongodb-persistence-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>process-mongodb-persistence-quarkus</artifactId>
   <name>Kogito Example :: Process MongoDB Persistence Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-mongodb-persistence-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-mongodb-persistence-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>process-mongodb-persistence-quarkus</artifactId>
   <name>Kogito Example :: Process MongoDB Persistence Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-monitoring-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-monitoring-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>process-monitoring-quarkus</artifactId>
   <name>Kogito Example :: Process Monitoring :: Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-monitoring-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-monitoring-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>process-monitoring-quarkus</artifactId>
   <name>Kogito Example :: Process Monitoring :: Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-outbox-mongodb-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-outbox-mongodb-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>process-outbox-mongodb-quarkus</artifactId>
@@ -41,8 +41,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
 
   <dependencyManagement>

--- a/kogito-quarkus-examples/process-outbox-mongodb-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-outbox-mongodb-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-outbox-mongodb-quarkus</artifactId>
@@ -41,8 +41,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
 
   <dependencyManagement>

--- a/kogito-quarkus-examples/process-performance-client/pom.xml
+++ b/kogito-quarkus-examples/process-performance-client/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>process-performance-client</artifactId>
   <name>Kogito Example :: Client Performance test</name>
@@ -39,8 +39,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-performance-client/pom.xml
+++ b/kogito-quarkus-examples/process-performance-client/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>process-performance-client</artifactId>
   <name>Kogito Example :: Client Performance test</name>
@@ -39,8 +39,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-performance-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-performance-quarkus/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>process-performance-quarkus</artifactId>
   <name>Kogito Example :: Quarkus Performance test</name>
@@ -39,8 +39,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-performance-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-performance-quarkus/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>process-performance-quarkus</artifactId>
   <name>Kogito Example :: Quarkus Performance test</name>
@@ -39,8 +39,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-postgresql-persistence-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-postgresql-persistence-quarkus/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-postgresql-persistence-quarkus</artifactId>
@@ -42,8 +42,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-postgresql-persistence-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-postgresql-persistence-quarkus/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>process-postgresql-persistence-quarkus</artifactId>
@@ -42,8 +42,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/process-quarkus-example/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>process-quarkus-example</artifactId>
   <name>Kogito Example :: Process and Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/process-quarkus-example/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>process-quarkus-example</artifactId>
   <name>Kogito Example :: Process and Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-rest-service-call-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-rest-service-call-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>process-rest-service-call-quarkus</artifactId>
   <name>Kogito Example :: Process Service Rest Cal with Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-rest-service-call-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-rest-service-call-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>process-rest-service-call-quarkus</artifactId>
   <name>Kogito Example :: Process Service Rest Cal with Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-rest-workitem-multi-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-rest-workitem-multi-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>process-rest-workitem-multi-quarkus</artifactId>
   <name>Kogito Example :: Process Rest :: Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-rest-workitem-multi-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-rest-workitem-multi-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>process-rest-workitem-multi-quarkus</artifactId>
   <name>Kogito Example :: Process Rest :: Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-rest-workitem-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-rest-workitem-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>process-rest-workitem-quarkus</artifactId>
   <name>Kogito Example :: Process Service Rest WorkItem call with Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-rest-workitem-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-rest-workitem-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>process-rest-workitem-quarkus</artifactId>
   <name>Kogito Example :: Process Service Rest WorkItem call with Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-saga-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-saga-quarkus/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-saga-quarkus</artifactId>
@@ -39,8 +39,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
 
   <dependencyManagement>

--- a/kogito-quarkus-examples/process-saga-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-saga-quarkus/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>process-saga-quarkus</artifactId>
@@ -39,8 +39,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
 
   <dependencyManagement>

--- a/kogito-quarkus-examples/process-scripts-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-scripts-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>process-scripts-quarkus</artifactId>
   <name>Kogito Example :: Process Scripts With Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-scripts-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-scripts-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>process-scripts-quarkus</artifactId>
   <name>Kogito Example :: Process Scripts With Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-service-calls-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-service-calls-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>process-service-calls-quarkus</artifactId>
   <name>Kogito Example :: Process Service Calls with Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-service-calls-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-service-calls-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>process-service-calls-quarkus</artifactId>
   <name>Kogito Example :: Process Service Calls with Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-timer-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-timer-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>process-timer-quarkus</artifactId>
   <name>Kogito Example :: Process Timer with Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-timer-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-timer-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>process-timer-quarkus</artifactId>
   <name>Kogito Example :: Process Timer with Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-usertasks-custom-lifecycle-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-custom-lifecycle-quarkus/pom.xml
@@ -27,7 +27,7 @@
    <parent>
       <groupId>org.kie.kogito.examples</groupId>
       <artifactId>kogito-quarkus-examples</artifactId>
-      <version>111-SNAPSHOIT</version>
+      <version>111-SNAPSHOT</version>
    </parent>
    <artifactId>process-usertasks-custom-lifecycle-quarkus</artifactId>
    <name>Kogito Example :: Process Usertasks With Custom Lifecycle</name>
@@ -39,8 +39,8 @@
       <quarkus.platform.version>3.27.3</quarkus.platform.version>
       <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
       <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-      <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-      <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+      <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+      <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
    </properties>
    <dependencyManagement>
       <dependencies>

--- a/kogito-quarkus-examples/process-usertasks-custom-lifecycle-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-custom-lifecycle-quarkus/pom.xml
@@ -27,7 +27,7 @@
    <parent>
       <groupId>org.kie.kogito.examples</groupId>
       <artifactId>kogito-quarkus-examples</artifactId>
-      <version>999-SNAPSHOT</version>
+      <version>111-SNAPSHOIT</version>
    </parent>
    <artifactId>process-usertasks-custom-lifecycle-quarkus</artifactId>
    <name>Kogito Example :: Process Usertasks With Custom Lifecycle</name>
@@ -39,8 +39,8 @@
       <quarkus.platform.version>3.27.3</quarkus.platform.version>
       <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
       <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-      <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-      <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+      <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+      <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
    </properties>
    <dependencyManagement>
       <dependencies>

--- a/kogito-quarkus-examples/process-usertasks-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>process-usertasks-quarkus</artifactId>
   <name>Kogito Example :: Process with Usertasks Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-usertasks-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>process-usertasks-quarkus</artifactId>
   <name>Kogito Example :: Process with Usertasks Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-usertasks-timer-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-timer-quarkus/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-usertasks-timer-quarkus</artifactId>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-usertasks-timer-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-timer-quarkus/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>process-usertasks-timer-quarkus</artifactId>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-usertasks-with-security-oidc-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-with-security-oidc-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>process-usertasks-with-security-oidc-quarkus</artifactId>
   <name>Kogito Example :: Process Usertasks With Security OIDC Keycloak Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-usertasks-with-security-oidc-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-with-security-oidc-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>process-usertasks-with-security-oidc-quarkus</artifactId>
   <name>Kogito Example :: Process Usertasks With Security OIDC Keycloak Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-usertasks-with-security-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-with-security-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>process-usertasks-with-security-quarkus</artifactId>
   <name>Kogito Example :: Process Usertasks With Security Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-usertasks-with-security-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-with-security-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>process-usertasks-with-security-quarkus</artifactId>
   <name>Kogito Example :: Process Usertasks With Security Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-usertasks-ws-humantask-lifecycle-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-ws-humantask-lifecycle-quarkus/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie.kogito.examples</groupId>
         <artifactId>kogito-quarkus-examples</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOIT</version>
     </parent>
 
     <artifactId>process-usertasks-ws-humantask-lifecycle-quarkus</artifactId>
@@ -41,7 +41,7 @@
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
         <kogito-apps.bom.artifact-id>kogito-apps-bom</kogito-apps.bom.artifact-id>
-        <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+        <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/kogito-quarkus-examples/process-usertasks-ws-humantask-lifecycle-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-ws-humantask-lifecycle-quarkus/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie.kogito.examples</groupId>
         <artifactId>kogito-quarkus-examples</artifactId>
-        <version>111-SNAPSHOIT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>process-usertasks-ws-humantask-lifecycle-quarkus</artifactId>
@@ -41,7 +41,7 @@
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
         <kogito-apps.bom.artifact-id>kogito-apps-bom</kogito-apps.bom.artifact-id>
-        <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+        <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/kogito-quarkus-examples/rules-incubation-api-quarkus/pom.xml
+++ b/kogito-quarkus-examples/rules-incubation-api-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>rules-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: Rules Incubation API With Quarkus</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/rules-incubation-api-quarkus/pom.xml
+++ b/kogito-quarkus-examples/rules-incubation-api-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>rules-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: Rules Incubation API With Quarkus</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/rules-legacy-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/rules-legacy-quarkus-example/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>rules-legacy-quarkus-example</artifactId>
   <name>Kogito Example :: Rules Legacy API - Quarkus</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/rules-legacy-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/rules-legacy-quarkus-example/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>rules-legacy-quarkus-example</artifactId>
   <name>Kogito Example :: Rules Legacy API - Quarkus</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/rules-legacy-scesim-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/rules-legacy-scesim-quarkus-example/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>rules-legacy-scesim-quarkus-example</artifactId>
   <name>Kogito Example :: Rules Legacy API HELLO - Quarkus :: Test Scenario</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/rules-legacy-scesim-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/rules-legacy-scesim-quarkus-example/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>rules-legacy-scesim-quarkus-example</artifactId>
   <name>Kogito Example :: Rules Legacy API HELLO - Quarkus :: Test Scenario</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/rules-quarkus-helloworld/pom.xml
+++ b/kogito-quarkus-examples/rules-quarkus-helloworld/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>rules-quarkus-helloworld</artifactId>
   <name>Kogito Example :: Rules HelloWorld</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/rules-quarkus-helloworld/pom.xml
+++ b/kogito-quarkus-examples/rules-quarkus-helloworld/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>rules-quarkus-helloworld</artifactId>
   <name>Kogito Example :: Rules HelloWorld</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/ruleunit-event-driven-quarkus/pom.xml
+++ b/kogito-quarkus-examples/ruleunit-event-driven-quarkus/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>ruleunit-event-driven-quarkus</artifactId>
   <name>Kogito Example :: Rule Unit Event-Driven :: Quarkus</name>
@@ -38,8 +38,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/ruleunit-event-driven-quarkus/pom.xml
+++ b/kogito-quarkus-examples/ruleunit-event-driven-quarkus/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>ruleunit-event-driven-quarkus</artifactId>
   <name>Kogito Example :: Rule Unit Event-Driven :: Quarkus</name>
@@ -38,8 +38,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/ruleunit-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/ruleunit-quarkus-example/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>ruleunit-quarkus-example</artifactId>
   <name>Kogito Example :: RuleUnit - Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/ruleunit-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/ruleunit-quarkus-example/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>ruleunit-quarkus-example</artifactId>
   <name>Kogito Example :: RuleUnit - Quarkus</name>
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/trusty-tracing-quarkus-devservices/pom.xml
+++ b/kogito-quarkus-examples/trusty-tracing-quarkus-devservices/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>trusty-tracing-quarkus-devservices</artifactId>
   <name>Kogito Example :: Trusty Tracing - Quarkus DevServices</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/trusty-tracing-quarkus-devservices/pom.xml
+++ b/kogito-quarkus-examples/trusty-tracing-quarkus-devservices/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>trusty-tracing-quarkus-devservices</artifactId>
   <name>Kogito Example :: Trusty Tracing - Quarkus DevServices</name>
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-springboot-examples/decisiontable-springboot-example/pom.xml
+++ b/kogito-springboot-examples/decisiontable-springboot-example/pom.xml
@@ -27,14 +27,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>decisiontable-springboot-example</artifactId>
   <name>Kogito Example :: Decision Table - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/decisiontable-springboot-example/pom.xml
+++ b/kogito-springboot-examples/decisiontable-springboot-example/pom.xml
@@ -27,14 +27,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>decisiontable-springboot-example</artifactId>
   <name>Kogito Example :: Decision Table - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/dmn-15-springboot-example/pom.xml
+++ b/kogito-springboot-examples/dmn-15-springboot-example/pom.xml
@@ -28,14 +28,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-15-springboot-example</artifactId>
   <name>Kogito Example :: DMN :: 1.5 Features</name>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <dependency-plugin.version>3.8.1</dependency-plugin.version>
   </properties>
 

--- a/kogito-springboot-examples/dmn-15-springboot-example/pom.xml
+++ b/kogito-springboot-examples/dmn-15-springboot-example/pom.xml
@@ -28,14 +28,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>dmn-15-springboot-example</artifactId>
   <name>Kogito Example :: DMN :: 1.5 Features</name>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <dependency-plugin.version>3.8.1</dependency-plugin.version>
   </properties>
 

--- a/kogito-springboot-examples/dmn-drools-springboot-metrics/pom.xml
+++ b/kogito-springboot-examples/dmn-drools-springboot-metrics/pom.xml
@@ -27,14 +27,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>dmn-drools-springboot-metrics</artifactId>
   <name>Kogito Example :: DMN Metrics SpringBoot</name>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/dmn-drools-springboot-metrics/pom.xml
+++ b/kogito-springboot-examples/dmn-drools-springboot-metrics/pom.xml
@@ -27,14 +27,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-drools-springboot-metrics</artifactId>
   <name>Kogito Example :: DMN Metrics SpringBoot</name>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/dmn-event-driven-springboot/pom.xml
+++ b/kogito-springboot-examples/dmn-event-driven-springboot/pom.xml
@@ -28,14 +28,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>dmn-event-driven-springboot</artifactId>
   <name>Kogito Example :: DMN Event-Driven :: Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/dmn-event-driven-springboot/pom.xml
+++ b/kogito-springboot-examples/dmn-event-driven-springboot/pom.xml
@@ -28,14 +28,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-event-driven-springboot</artifactId>
   <name>Kogito Example :: DMN Event-Driven :: Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/dmn-listener-springboot/pom.xml
+++ b/kogito-springboot-examples/dmn-listener-springboot/pom.xml
@@ -28,14 +28,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>dmn-listener-springboot</artifactId>
   <name>Kogito Example :: DMN with listeners - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/dmn-listener-springboot/pom.xml
+++ b/kogito-springboot-examples/dmn-listener-springboot/pom.xml
@@ -28,14 +28,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-listener-springboot</artifactId>
   <name>Kogito Example :: DMN with listeners - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/dmn-pmml-springboot-example/pom.xml
+++ b/kogito-springboot-examples/dmn-pmml-springboot-example/pom.xml
@@ -27,14 +27,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-pmml-springboot-example</artifactId>
   <name>Kogito Example :: DMN :: PMML - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/dmn-pmml-springboot-example/pom.xml
+++ b/kogito-springboot-examples/dmn-pmml-springboot-example/pom.xml
@@ -27,14 +27,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>dmn-pmml-springboot-example</artifactId>
   <name>Kogito Example :: DMN :: PMML - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/dmn-resource-jar-springboot-example/dmn-springboot-consumer-example/pom.xml
+++ b/kogito-springboot-examples/dmn-resource-jar-springboot-example/dmn-springboot-consumer-example/pom.xml
@@ -28,14 +28,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>dmn-resource-jar-springboot-example</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>dmn-springboot-consumer-example</artifactId>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <dependency-plugin.version>3.6.1</dependency-plugin.version>
   </properties>
 

--- a/kogito-springboot-examples/dmn-resource-jar-springboot-example/dmn-springboot-consumer-example/pom.xml
+++ b/kogito-springboot-examples/dmn-resource-jar-springboot-example/dmn-springboot-consumer-example/pom.xml
@@ -28,14 +28,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>dmn-resource-jar-springboot-example</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>dmn-springboot-consumer-example</artifactId>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <dependency-plugin.version>3.6.1</dependency-plugin.version>
   </properties>
 

--- a/kogito-springboot-examples/dmn-resource-jar-springboot-example/dmn-springboot-resource-jar/pom.xml
+++ b/kogito-springboot-examples/dmn-resource-jar-springboot-example/dmn-springboot-resource-jar/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>dmn-resource-jar-springboot-example</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>dmn-springboot-resource-jar</artifactId>

--- a/kogito-springboot-examples/dmn-resource-jar-springboot-example/dmn-springboot-resource-jar/pom.xml
+++ b/kogito-springboot-examples/dmn-resource-jar-springboot-example/dmn-springboot-resource-jar/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>dmn-resource-jar-springboot-example</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>dmn-springboot-resource-jar</artifactId>

--- a/kogito-springboot-examples/dmn-resource-jar-springboot-example/pom.xml
+++ b/kogito-springboot-examples/dmn-resource-jar-springboot-example/pom.xml
@@ -28,15 +28,15 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>dmn-resource-jar-springboot-example</artifactId>
   <name>Kogito Example :: DMN :: Resource jar providing model</name>
   <packaging>pom</packaging>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <modules>

--- a/kogito-springboot-examples/dmn-resource-jar-springboot-example/pom.xml
+++ b/kogito-springboot-examples/dmn-resource-jar-springboot-example/pom.xml
@@ -28,15 +28,15 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-resource-jar-springboot-example</artifactId>
   <name>Kogito Example :: DMN :: Resource jar providing model</name>
   <packaging>pom</packaging>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <modules>

--- a/kogito-springboot-examples/dmn-springboot-example/pom.xml
+++ b/kogito-springboot-examples/dmn-springboot-example/pom.xml
@@ -28,14 +28,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-springboot-example</artifactId>
   <name>Kogito Example :: DMN - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/dmn-springboot-example/pom.xml
+++ b/kogito-springboot-examples/dmn-springboot-example/pom.xml
@@ -28,14 +28,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>dmn-springboot-example</artifactId>
   <name>Kogito Example :: DMN - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/dmn-tracing-springboot/pom.xml
+++ b/kogito-springboot-examples/dmn-tracing-springboot/pom.xml
@@ -28,14 +28,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>dmn-tracing-springboot</artifactId>
   <name>Kogito Example :: DMN Tracing - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/dmn-tracing-springboot/pom.xml
+++ b/kogito-springboot-examples/dmn-tracing-springboot/pom.xml
@@ -28,14 +28,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-tracing-springboot</artifactId>
   <name>Kogito Example :: DMN Tracing - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/flexible-process-springboot/pom.xml
+++ b/kogito-springboot-examples/flexible-process-springboot/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>flexible-process-springboot</artifactId>
@@ -34,8 +34,8 @@
   <description>Kogito service invocation - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/flexible-process-springboot/pom.xml
+++ b/kogito-springboot-examples/flexible-process-springboot/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>flexible-process-springboot</artifactId>
@@ -34,8 +34,8 @@
   <description>Kogito service invocation - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/onboarding-springboot/pom.xml
+++ b/kogito-springboot-examples/onboarding-springboot/pom.xml
@@ -25,15 +25,15 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>onboarding-springboot</artifactId>
   <name>Kogito Example :: Onboarding Example :: Onboarding with Business Process Spring Boot</name>
   <description>Onboarding function and service orchestration</description>
   
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/onboarding-springboot/pom.xml
+++ b/kogito-springboot-examples/onboarding-springboot/pom.xml
@@ -25,15 +25,15 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>onboarding-springboot</artifactId>
   <name>Kogito Example :: Onboarding Example :: Onboarding with Business Process Spring Boot</name>
   <description>Onboarding function and service orchestration</description>
   
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/pmml-event-driven-springboot/pom.xml
+++ b/kogito-springboot-examples/pmml-event-driven-springboot/pom.xml
@@ -27,14 +27,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>pmml-event-driven-springboot</artifactId>
   <name>Kogito Example :: PMML Event-Driven - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/pmml-event-driven-springboot/pom.xml
+++ b/kogito-springboot-examples/pmml-event-driven-springboot/pom.xml
@@ -27,14 +27,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>pmml-event-driven-springboot</artifactId>
   <name>Kogito Example :: PMML Event-Driven - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/pmml-springboot-example/pom.xml
+++ b/kogito-springboot-examples/pmml-springboot-example/pom.xml
@@ -27,14 +27,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>pmml-springboot-example</artifactId>
   <name>Kogito Example :: PMML - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/pmml-springboot-example/pom.xml
+++ b/kogito-springboot-examples/pmml-springboot-example/pom.xml
@@ -27,14 +27,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>pmml-springboot-example</artifactId>
   <name>Kogito Example :: PMML - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/pom.xml
+++ b/kogito-springboot-examples/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>kogito-springboot-examples</artifactId>

--- a/kogito-springboot-examples/pom.xml
+++ b/kogito-springboot-examples/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-springboot-examples</artifactId>

--- a/kogito-springboot-examples/process-business-calendar-springboot-example/pom.xml
+++ b/kogito-springboot-examples/process-business-calendar-springboot-example/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <name>Kogito Example :: Process Business Calendar Spring Boot</name>
@@ -14,8 +14,8 @@
   <description>Kogito business calendar usage - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-business-calendar-springboot-example/pom.xml
+++ b/kogito-springboot-examples/process-business-calendar-springboot-example/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <name>Kogito Example :: Process Business Calendar Spring Boot</name>
@@ -14,8 +14,8 @@
   <description>Kogito business calendar usage - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-business-rules-springboot/pom.xml
+++ b/kogito-springboot-examples/process-business-rules-springboot/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <name>Kogito Example :: Process Business Rules Spring Boot</name>
@@ -34,8 +34,8 @@
   <description>Kogito business rules invocation - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-business-rules-springboot/pom.xml
+++ b/kogito-springboot-examples/process-business-rules-springboot/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <name>Kogito Example :: Process Business Rules Spring Boot</name>
@@ -34,8 +34,8 @@
   <description>Kogito business rules invocation - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-decisions-rest-springboot/pom.xml
+++ b/kogito-springboot-examples/process-decisions-rest-springboot/pom.xml
@@ -25,15 +25,15 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>process-decisions-rest-springboot</artifactId>
   <name>Kogito Example :: Process :: Decisions :: REST :: Spring Boot</name>
   <description>Process with DMN and DRL integration through REST - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-decisions-rest-springboot/pom.xml
+++ b/kogito-springboot-examples/process-decisions-rest-springboot/pom.xml
@@ -25,15 +25,15 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>process-decisions-rest-springboot</artifactId>
   <name>Kogito Example :: Process :: Decisions :: REST :: Spring Boot</name>
   <description>Process with DMN and DRL integration through REST - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-decisions-rules-springboot-yaml/pom.xml
+++ b/kogito-springboot-examples/process-decisions-rules-springboot-yaml/pom.xml
@@ -25,15 +25,15 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>process-decisions-rules-springboot-yaml</artifactId>
   <name>Kogito Example :: Process :: Decisions :: Rules :: Spring Boot :: YaML</name>
   <description>Process with DRL, DMN and DRL integration - Spring Boot - YaML configuration</description>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-decisions-rules-springboot-yaml/pom.xml
+++ b/kogito-springboot-examples/process-decisions-rules-springboot-yaml/pom.xml
@@ -25,15 +25,15 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>process-decisions-rules-springboot-yaml</artifactId>
   <name>Kogito Example :: Process :: Decisions :: Rules :: Spring Boot :: YaML</name>
   <description>Process with DRL, DMN and DRL integration - Spring Boot - YaML configuration</description>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-decisions-rules-springboot/pom.xml
+++ b/kogito-springboot-examples/process-decisions-rules-springboot/pom.xml
@@ -25,15 +25,15 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>process-decisions-rules-springboot</artifactId>
   <name>Kogito Example :: Process :: Decisions :: Rules :: Spring Boot</name>
   <description>Process with DRL, DMN and DRL integration - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-decisions-rules-springboot/pom.xml
+++ b/kogito-springboot-examples/process-decisions-rules-springboot/pom.xml
@@ -25,15 +25,15 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>process-decisions-rules-springboot</artifactId>
   <name>Kogito Example :: Process :: Decisions :: Rules :: Spring Boot</name>
   <description>Process with DRL, DMN and DRL integration - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-decisions-springboot/pom.xml
+++ b/kogito-springboot-examples/process-decisions-springboot/pom.xml
@@ -25,15 +25,15 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>process-decisions-springboot</artifactId>
   <name>Kogito Example :: Process :: Decisions :: Spring Boot</name>
   <description>Process with DMN and DRL integration - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-decisions-springboot/pom.xml
+++ b/kogito-springboot-examples/process-decisions-springboot/pom.xml
@@ -25,15 +25,15 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>process-decisions-springboot</artifactId>
   <name>Kogito Example :: Process :: Decisions :: Spring Boot</name>
   <description>Process with DMN and DRL integration - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-infinispan-persistence-springboot/pom.xml
+++ b/kogito-springboot-examples/process-infinispan-persistence-springboot/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>process-infinispan-persistence-springboot</artifactId>
@@ -34,8 +34,8 @@
   <description>Kogito with Infinispan persistence - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-infinispan-persistence-springboot/pom.xml
+++ b/kogito-springboot-examples/process-infinispan-persistence-springboot/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-infinispan-persistence-springboot</artifactId>
@@ -34,8 +34,8 @@
   <description>Kogito with Infinispan persistence - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-kafka-multi-springboot/pom.xml
+++ b/kogito-springboot-examples/process-kafka-multi-springboot/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>process-kafka-multi-springboot</artifactId>
@@ -34,8 +34,8 @@
   <description>Kogito with Kafka - Spring Boot, using multiple channels</description>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-kafka-multi-springboot/pom.xml
+++ b/kogito-springboot-examples/process-kafka-multi-springboot/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-kafka-multi-springboot</artifactId>
@@ -34,8 +34,8 @@
   <description>Kogito with Kafka - Spring Boot, using multiple channels</description>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-kafka-quickstart-springboot/pom.xml
+++ b/kogito-springboot-examples/process-kafka-quickstart-springboot/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>process-kafka-quickstart-springboot</artifactId>
@@ -34,8 +34,8 @@
   <description>Kogito with Kafka - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-kafka-quickstart-springboot/pom.xml
+++ b/kogito-springboot-examples/process-kafka-quickstart-springboot/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-kafka-quickstart-springboot</artifactId>
@@ -34,8 +34,8 @@
   <description>Kogito with Kafka - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-mongodb-persistence-springboot/pom.xml
+++ b/kogito-springboot-examples/process-mongodb-persistence-springboot/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-mongodb-persistence-springboot</artifactId>
@@ -35,8 +35,8 @@
 
   <properties>
     <enable.resource.mongodb>true</enable.resource.mongodb>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-mongodb-persistence-springboot/pom.xml
+++ b/kogito-springboot-examples/process-mongodb-persistence-springboot/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>process-mongodb-persistence-springboot</artifactId>
@@ -35,8 +35,8 @@
 
   <properties>
     <enable.resource.mongodb>true</enable.resource.mongodb>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-monitoring-springboot/pom.xml
+++ b/kogito-springboot-examples/process-monitoring-springboot/pom.xml
@@ -26,15 +26,15 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-monitoring-springboot</artifactId>
   <name>Kogito Example :: Process Monitoring :: Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-monitoring-springboot/pom.xml
+++ b/kogito-springboot-examples/process-monitoring-springboot/pom.xml
@@ -26,15 +26,15 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>process-monitoring-springboot</artifactId>
   <name>Kogito Example :: Process Monitoring :: Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-outbox-mongodb-springboot/pom.xml
+++ b/kogito-springboot-examples/process-outbox-mongodb-springboot/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>process-outbox-mongodb-springboot</artifactId>
@@ -35,8 +35,8 @@
 
   <properties>
     <DEBEZIUM_VERSION>1.7</DEBEZIUM_VERSION>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-outbox-mongodb-springboot/pom.xml
+++ b/kogito-springboot-examples/process-outbox-mongodb-springboot/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-outbox-mongodb-springboot</artifactId>
@@ -35,8 +35,8 @@
 
   <properties>
     <DEBEZIUM_VERSION>1.7</DEBEZIUM_VERSION>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-performance-springboot/pom.xml
+++ b/kogito-springboot-examples/process-performance-springboot/pom.xml
@@ -27,15 +27,15 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>process-performance-springboot</artifactId>
   <name>Kogito Example :: Springboot Performance test</name>
   <description>Springboot Performance test</description>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-performance-springboot/pom.xml
+++ b/kogito-springboot-examples/process-performance-springboot/pom.xml
@@ -27,15 +27,15 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>process-performance-springboot</artifactId>
   <name>Kogito Example :: Springboot Performance test</name>
   <description>Springboot Performance test</description>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-postgresql-persistence-springboot/pom.xml
+++ b/kogito-springboot-examples/process-postgresql-persistence-springboot/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>process-postgresql-persistence-springboot</artifactId>
@@ -34,8 +34,8 @@
   <description>Kogito with PostgreSQL persistence - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-postgresql-persistence-springboot/pom.xml
+++ b/kogito-springboot-examples/process-postgresql-persistence-springboot/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-postgresql-persistence-springboot</artifactId>
@@ -34,8 +34,8 @@
   <description>Kogito with PostgreSQL persistence - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-rest-service-call-springboot/pom.xml
+++ b/kogito-springboot-examples/process-rest-service-call-springboot/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-rest-service-call-springboot</artifactId>
@@ -34,8 +34,8 @@
   <description>Kogito service invocation with REST - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-rest-service-call-springboot/pom.xml
+++ b/kogito-springboot-examples/process-rest-service-call-springboot/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>process-rest-service-call-springboot</artifactId>
@@ -34,8 +34,8 @@
   <description>Kogito service invocation with REST - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-scripts-springboot/pom.xml
+++ b/kogito-springboot-examples/process-scripts-springboot/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-scripts-springboot</artifactId>
@@ -34,8 +34,8 @@
   <description>Kogito script invocation - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-scripts-springboot/pom.xml
+++ b/kogito-springboot-examples/process-scripts-springboot/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>process-scripts-springboot</artifactId>
@@ -34,8 +34,8 @@
   <description>Kogito script invocation - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-service-calls-springboot/pom.xml
+++ b/kogito-springboot-examples/process-service-calls-springboot/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>process-service-calls-springboot</artifactId>
@@ -34,8 +34,8 @@
   <description>Kogito service invocation - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-service-calls-springboot/pom.xml
+++ b/kogito-springboot-examples/process-service-calls-springboot/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-service-calls-springboot</artifactId>
@@ -34,8 +34,8 @@
   <description>Kogito service invocation - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-springboot-example/pom.xml
+++ b/kogito-springboot-examples/process-springboot-example/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-springboot-example</artifactId>
@@ -34,8 +34,8 @@
   <description>Order management service</description>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-springboot-example/pom.xml
+++ b/kogito-springboot-examples/process-springboot-example/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>process-springboot-example</artifactId>
@@ -34,8 +34,8 @@
   <description>Order management service</description>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-timer-springboot/pom.xml
+++ b/kogito-springboot-examples/process-timer-springboot/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-timer-springboot</artifactId>
@@ -32,8 +32,8 @@
   <description>Kogito with timers - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-timer-springboot/pom.xml
+++ b/kogito-springboot-examples/process-timer-springboot/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>process-timer-springboot</artifactId>
@@ -32,8 +32,8 @@
   <description>Kogito with timers - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-usertasks-custom-lifecycle-springboot/pom.xml
+++ b/kogito-springboot-examples/process-usertasks-custom-lifecycle-springboot/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>process-usertasks-custom-lifecycle-springboot</artifactId>
@@ -34,8 +34,8 @@
   <description>Kogito usertasks orchestration with custom life cycle - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-usertasks-custom-lifecycle-springboot/pom.xml
+++ b/kogito-springboot-examples/process-usertasks-custom-lifecycle-springboot/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-usertasks-custom-lifecycle-springboot</artifactId>
@@ -34,8 +34,8 @@
   <description>Kogito usertasks orchestration with custom life cycle - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-usertasks-springboot/pom.xml
+++ b/kogito-springboot-examples/process-usertasks-springboot/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-usertasks-springboot</artifactId>
@@ -34,8 +34,8 @@
   <description>Kogito usertasks orchestration - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-usertasks-springboot/pom.xml
+++ b/kogito-springboot-examples/process-usertasks-springboot/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>process-usertasks-springboot</artifactId>
@@ -34,8 +34,8 @@
   <description>Kogito usertasks orchestration - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-usertasks-with-security-oidc-springboot/pom.xml
+++ b/kogito-springboot-examples/process-usertasks-with-security-oidc-springboot/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>process-usertasks-with-security-oidc-springboot</artifactId>
@@ -34,8 +34,8 @@
   <description>Kogito usertasks orchestration with security enabled on REST api - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-usertasks-with-security-oidc-springboot/pom.xml
+++ b/kogito-springboot-examples/process-usertasks-with-security-oidc-springboot/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-usertasks-with-security-oidc-springboot</artifactId>
@@ -34,8 +34,8 @@
   <description>Kogito usertasks orchestration with security enabled on REST api - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-usertasks-with-security-springboot/pom.xml
+++ b/kogito-springboot-examples/process-usertasks-with-security-springboot/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>process-usertasks-with-security-springboot</artifactId>
@@ -34,8 +34,8 @@
   <description>Kogito usertasks orchestration with security enabled on REST api - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-usertasks-with-security-springboot/pom.xml
+++ b/kogito-springboot-examples/process-usertasks-with-security-springboot/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-usertasks-with-security-springboot</artifactId>
@@ -34,8 +34,8 @@
   <description>Kogito usertasks orchestration with security enabled on REST api - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/rules-legacy-scesim-springboot-example/pom.xml
+++ b/kogito-springboot-examples/rules-legacy-scesim-springboot-example/pom.xml
@@ -27,14 +27,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>rules-legacy-scesim-springboot-example</artifactId>
   <name>Kogito Example :: Rules Legacy API HELLO - Spring Boot :: Test Scenario</name>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <kogito.sources.keep>true</kogito.sources.keep>
   </properties>
 

--- a/kogito-springboot-examples/rules-legacy-scesim-springboot-example/pom.xml
+++ b/kogito-springboot-examples/rules-legacy-scesim-springboot-example/pom.xml
@@ -27,14 +27,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>rules-legacy-scesim-springboot-example</artifactId>
   <name>Kogito Example :: Rules Legacy API HELLO - Spring Boot :: Test Scenario</name>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <kogito.sources.keep>true</kogito.sources.keep>
   </properties>
 

--- a/kogito-springboot-examples/rules-legacy-springboot-example/pom.xml
+++ b/kogito-springboot-examples/rules-legacy-springboot-example/pom.xml
@@ -27,14 +27,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>rules-legacy-springboot-example</artifactId>
   <name>Kogito Example :: Rules Legacy API - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/rules-legacy-springboot-example/pom.xml
+++ b/kogito-springboot-examples/rules-legacy-springboot-example/pom.xml
@@ -27,14 +27,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>rules-legacy-springboot-example</artifactId>
   <name>Kogito Example :: Rules Legacy API - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/ruleunit-event-driven-springboot/pom.xml
+++ b/kogito-springboot-examples/ruleunit-event-driven-springboot/pom.xml
@@ -27,14 +27,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>ruleunit-event-driven-springboot</artifactId>
   <name>Kogito Example :: RuleUnit Event Driven :: Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/ruleunit-event-driven-springboot/pom.xml
+++ b/kogito-springboot-examples/ruleunit-event-driven-springboot/pom.xml
@@ -27,14 +27,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>ruleunit-event-driven-springboot</artifactId>
   <name>Kogito Example :: RuleUnit Event Driven :: Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/ruleunit-springboot-example/pom.xml
+++ b/kogito-springboot-examples/ruleunit-springboot-example/pom.xml
@@ -27,14 +27,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>ruleunit-springboot-example</artifactId>
   <name>Kogito Example :: RuleUnit - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/ruleunit-springboot-example/pom.xml
+++ b/kogito-springboot-examples/ruleunit-springboot-example/pom.xml
@@ -27,14 +27,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>ruleunit-springboot-example</artifactId>
   <name>Kogito Example :: RuleUnit - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,10 @@
 
   <url>http://kogito.kie.org</url>
   <inceptionYear>2019</inceptionYear>
-
+  <organization>
+    <name>The Apache Software Foundation</name>
+    <url>https://apache.org/</url>
+  </organization>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/pom.xml
+++ b/pom.xml
@@ -36,14 +36,10 @@
   <packaging>pom</packaging>
 
   <name>Kogito Example</name>
-  <description>Kogito Example</description>
+  <description>This repository is a fork of https://github.com/apache/incubator-kie-kogito-examples used for the purposes od SonataFlow.</description>
 
   <url>http://kogito.kie.org</url>
   <inceptionYear>2019</inceptionYear>
-  <organization>
-    <name>The Apache Software Foundation</name>
-    <url>https://apache.org/</url>
-  </organization>
 
   <licenses>
     <license>
@@ -54,44 +50,68 @@
   </licenses>
 
   <scm>
-    <connection>scm:git:https://github.com/apache/incubator-kie-kogito-examples.git</connection>
-    <developerConnection>scm:git:https://github.com/apache/incubator-kie-kogito-examples.git</developerConnection>
-    <url>https://github.com/apache/incubator-kie-kogito-examples</url>
+    <connection>scm:git:https://github.com/kiegroup/kogito-examples.git</connection>
+    <developerConnection>scm:git:https://github.com/kiegroup/kogito-examples.git</developerConnection>
+    <url>https://github.com/kiegroup/kogito-examples</url>
   </scm>
 
-  <developers>
-    <developer>
-      <name>The Apache KIE Team</name>
-      <email>dev@kie.apache.org</email>
-      <url>https://kie.apache.org</url>
-      <organization>Apache Software Foundation</organization>
-      <organizationUrl>http://apache.org/</organizationUrl>
-    </developer>
-  </developers>
+  <distributionManagement>
+    <repository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/kubesmarts/sonataflow-maven-repository</url>
+    </repository>
+    <snapshotRepository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/kubesmarts/sonataflow-maven-repository</url>
+    </snapshotRepository>
+  </distributionManagement>
 
-  <mailingLists>
-    <mailingList>
-      <name>Development List</name>
-      <subscribe>dev-subscribe@kie.apache.org</subscribe>
-      <unsubscribe>dev-unsubscribe@kie.apache.org</unsubscribe>
-      <post>dev@kie.apache.org</post>
-      <archive>https://lists.apache.org/list.html?dev@kie.apache.org</archive>
-    </mailingList>
-    <mailingList>
-      <name>User List</name>
-      <subscribe>users-subscribe@kie.apache.org</subscribe>
-      <unsubscribe>users-unsubscribe@kie.apache.org</unsubscribe>
-      <post>users@kie.apache.org</post>
-      <archive>https://lists.apache.org/list.html?users@kie.apache.org</archive>
-    </mailingList>
-    <mailingList>
-      <name>Commits List</name>
-      <subscribe>commits-subscribe@kie.apache.org</subscribe>
-      <unsubscribe>commits-unsubscribe@kie.apache.org</unsubscribe>
-      <post>commits@kie.apache.org</post>
-      <archive>https://lists.apache.org/list.html?commits@kie.apache.org</archive>
-    </mailingList>
-  </mailingLists>
+  <repositories>
+    <repository>
+      <id>central</id>
+      <name>Central</name>
+      <url>https://repo1.maven.org/maven2/</url>
+    </repository>
+    <repository>
+      <id>github</id>
+      <name>GitHub Repository</name>
+      <url>https://maven.pkg.github.com/kubesmarts/sonataflow-maven-repository</url>
+    </repository>
+    <repository>
+      <id>redhat-ga-repository</id>
+      <url>https://maven.repository.redhat.com/ga</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>central</id>
+      <name>Central</name>
+      <url>https://repo1.maven.org/maven2/</url>
+    </pluginRepository>
+    <pluginRepository>
+      <id>github</id>
+      <name>GitHub Repository</name>
+      <url>https://maven.pkg.github.com/kubesmarts/sonataflow-maven-repository</url>
+    </pluginRepository>
+    <pluginRepository>
+      <id>redhat-ga-plugin-repository</id>
+      <url>https://maven.repository.redhat.com/ga</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -117,18 +137,6 @@
     <project.build.outputTimestamp>2024-01-16T00:00:00Z</project.build.outputTimestamp>
     <version.maven.artifact.plugin>3.4.1</version.maven.artifact.plugin>
   </properties>
-
-  <repositories>
-    <!-- useful to resolve parent pom when it is a SNAPSHOT -->
-    <repository>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <id>apache.snapshots</id>
-      <name>Apache Snapshot Repository</name>
-      <url>https://repository.apache.org/snapshots</url>
-    </repository>
-  </repositories>
 
   <profiles>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-no-bom-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <groupId>org.kie.kogito.examples</groupId>
@@ -72,7 +72,7 @@
     <repository>
       <id>central</id>
       <name>Central</name>
-      <url>https://repo1.maven.org/maven2/</url>
+      <url>https://repo.maven.apache.org/maven2/</url>
     </repository>
     <repository>
       <id>github</id>
@@ -94,7 +94,7 @@
     <pluginRepository>
       <id>central</id>
       <name>Central</name>
-      <url>https://repo1.maven.org/maven2/</url>
+      <url>https://repo.maven.apache.org/maven2/</url>
     </pluginRepository>
     <pluginRepository>
       <id>github</id>
@@ -116,7 +116,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
 
     <surefire.forkCount>1</surefire.forkCount>
     <failsafe.include>**/*IT.java</failsafe.include>

--- a/pom.xml
+++ b/pom.xml
@@ -145,11 +145,7 @@
         <activeByDefault>true</activeByDefault>
       </activation>
       <modules>
-        <module>kogito-java-examples</module>
-        <module>kogito-quarkus-examples</module>
-        <module>kogito-springboot-examples</module>
         <module>serverless-workflow-examples</module>
-        <module>gradle-examples</module>
       </modules>
     </profile>
   </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-no-bom-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <groupId>org.kie.kogito.examples</groupId>
@@ -116,7 +116,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
 
     <surefire.forkCount>1</surefire.forkCount>
     <failsafe.include>**/*IT.java</failsafe.include>

--- a/serverless-workflow-examples/pom.xml
+++ b/serverless-workflow-examples/pom.xml
@@ -45,21 +45,16 @@
         <module>serverless-workflow-annotations-description</module>
         <module>serverless-workflow-callback-events-over-http-quarkus</module>
         <module>serverless-workflow-callback-quarkus</module>
-        <module>serverless-workflow-camel-routes</module>
         <module>serverless-workflow-compensation-quarkus</module>
         <module>serverless-workflow-consuming-events-over-http-quarkus</module>
         <module>serverless-workflow-correlation-quarkus</module>
         <module>serverless-workflow-correlation-quarkus-mongodb</module>
         <module>serverless-workflow-custom-function-knative</module>
         <module>serverless-workflow-custom-type</module>
-        <module>serverless-workflow-data-index-persistence-addon-quarkus</module>
         <module>serverless-workflow-data-index-quarkus</module>
-        <module>serverless-workflow-dmn-quarkus</module>
         <module>serverless-workflow-error-quarkus</module>
-        <module>serverless-workflow-events-quarkus</module>
         <module>serverless-workflow-expression-quarkus</module>
         <module>serverless-workflow-foreach-quarkus</module>
-        <module>serverless-workflow-functions-events-quarkus</module>
         <module>serverless-workflow-functions-quarkus</module>
         <module>serverless-workflow-funqy</module>
         <module>serverless-workflow-greeting-quarkus</module>
@@ -67,7 +62,6 @@
         <module>serverless-workflow-hello-world</module>
         <module>serverless-workflow-loanbroker-showcase</module>
         <module>serverless-workflow-newsletter-subscription</module>
-        <module>serverless-workflow-oauth2-orchestration-quarkus</module>
         <module>serverless-workflow-order-processing</module>
         <module>serverless-workflow-parallel-execution</module>
         <module>serverless-workflow-qas-service-showcase</module>
@@ -79,9 +73,7 @@
         <module>serverless-workflow-timeouts-showcase-embedded</module>
         <module>serverless-workflow-timeouts-showcase-extended</module>
         <module>serverless-workflow-timeouts-showcase-operator-devprofile</module>
-        <module>serverless-workflow-python-quarkus</module>
         <module>sonataflow-fluent</module>
-	<module>serverless-workflow-fault-tolerance</module>
 	<module>serverless-workflow-opentelemetry-jaeger-quarkus</module>
       </modules>
     </profile>
@@ -112,13 +104,11 @@
         <module>serverless-workflow-data-index-quarkus</module>
         <module>serverless-workflow-compensation-quarkus</module>
         <module>serverless-workflow-error-quarkus</module>
-        <module>serverless-workflow-events-quarkus</module>
         <module>serverless-workflow-expression-quarkus</module>
         <module>serverless-workflow-foreach-quarkus</module>
         <module>serverless-workflow-funqy</module>
         <module>serverless-workflow-greeting-quarkus</module>
         <module>serverless-workflow-newsletter-subscription</module>
-        <module>serverless-workflow-oauth2-orchestration-quarkus</module>
         <module>serverless-workflow-service-calls-quarkus</module>
         <module>serverless-workflow-temperature-conversion</module>
         <module>serverless-workflow-custom-type</module>

--- a/serverless-workflow-examples/pom.xml
+++ b/serverless-workflow-examples/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>serverless-workflow-examples</artifactId>

--- a/serverless-workflow-examples/pom.xml
+++ b/serverless-workflow-examples/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
 
   <artifactId>serverless-workflow-examples</artifactId>

--- a/serverless-workflow-examples/serverless-workflow-annotations-description/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-annotations-description/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -45,7 +45,7 @@
         <version.org.assertj>3.27.7</version.org.assertj>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+        <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
         <version.compiler.plugin>3.13.0</version.compiler.plugin>
         <maven.compiler.release>17</maven.compiler.release>
         <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-annotations-description/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-annotations-description/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -45,7 +45,7 @@
         <version.org.assertj>3.27.7</version.org.assertj>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+        <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
         <version.compiler.plugin>3.13.0</version.compiler.plugin>
         <maven.compiler.release>17</maven.compiler.release>
         <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/callback-event-service/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/callback-event-service/pom.xml
@@ -38,7 +38,7 @@
         <quarkus.platform.version>3.27.3</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+        <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
         <version.compiler.plugin>3.13.0</version.compiler.plugin>
         <maven.compiler.release>17</maven.compiler.release>
         <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/callback-event-service/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/callback-event-service/pom.xml
@@ -38,7 +38,7 @@
         <quarkus.platform.version>3.27.3</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+        <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
         <version.compiler.plugin>3.13.0</version.compiler.plugin>
         <maven.compiler.release>17</maven.compiler.release>
         <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/callback-workflow/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/callback-workflow/pom.xml
@@ -39,7 +39,7 @@
         <quarkus.platform.version>3.27.3</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+        <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
         <version.compiler.plugin>3.13.0</version.compiler.plugin>
         <maven.compiler.release>17</maven.compiler.release>
         <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/callback-workflow/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/callback-workflow/pom.xml
@@ -39,7 +39,7 @@
         <quarkus.platform.version>3.27.3</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+        <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
         <version.compiler.plugin>3.13.0</version.compiler.plugin>
         <maven.compiler.release>17</maven.compiler.release>
         <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/pom.xml
@@ -28,7 +28,7 @@
     <parent>
       <groupId>org.kie.kogito.examples</groupId>
       <artifactId>serverless-workflow-examples-parent</artifactId>
-      <version>111-SNAPSHOIT</version>
+      <version>111-SNAPSHOT</version>
       <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
     </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/pom.xml
@@ -28,7 +28,7 @@
     <parent>
       <groupId>org.kie.kogito.examples</groupId>
       <artifactId>serverless-workflow-examples-parent</artifactId>
-      <version>999-SNAPSHOT</version>
+      <version>111-SNAPSHOIT</version>
       <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
     </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-callback-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-callback-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-callback-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-callback-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-camel-routes/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-camel-routes/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -45,7 +45,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <maven.compiler.release>17</maven.compiler.release>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-camel-routes/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-camel-routes/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -45,7 +45,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <maven.compiler.release>17</maven.compiler.release>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-compensation-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-compensation-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>
     <maven.compiler.release>17</maven.compiler.release>

--- a/serverless-workflow-examples/serverless-workflow-compensation-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-compensation-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>
     <maven.compiler.release>17</maven.compiler.release>

--- a/serverless-workflow-examples/serverless-workflow-consuming-events-over-http-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-consuming-events-over-http-quarkus/pom.xml
@@ -28,7 +28,7 @@
     <parent>
       <groupId>org.kie.kogito.examples</groupId>
       <artifactId>serverless-workflow-examples-parent</artifactId>
-      <version>111-SNAPSHOIT</version>
+      <version>111-SNAPSHOT</version>
       <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
     </parent>
 
@@ -45,7 +45,7 @@
         <quarkus.platform.version>3.27.3</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+        <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
         <version.compiler.plugin>3.13.0</version.compiler.plugin>
         <maven.compiler.release>17</maven.compiler.release>
         <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-consuming-events-over-http-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-consuming-events-over-http-quarkus/pom.xml
@@ -28,7 +28,7 @@
     <parent>
       <groupId>org.kie.kogito.examples</groupId>
       <artifactId>serverless-workflow-examples-parent</artifactId>
-      <version>999-SNAPSHOT</version>
+      <version>111-SNAPSHOIT</version>
       <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
     </parent>
 
@@ -45,7 +45,7 @@
         <quarkus.platform.version>3.27.3</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+        <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
         <version.compiler.plugin>3.13.0</version.compiler.plugin>
         <maven.compiler.release>17</maven.compiler.release>
         <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-correlation-quarkus-mongodb/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-correlation-quarkus-mongodb/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-correlation-quarkus-mongodb/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-correlation-quarkus-mongodb/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-correlation-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-correlation-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-correlation-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-correlation-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-custom-function-knative/custom-function-knative-service/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-custom-function-knative/custom-function-knative-service/pom.xml
@@ -38,7 +38,7 @@
         <quarkus.platform.version>3.27.3</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+        <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
         <version.compiler.plugin>3.11.0</version.compiler.plugin>
         <maven.compiler.release>17</maven.compiler.release>
         <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-custom-function-knative/custom-function-knative-service/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-custom-function-knative/custom-function-knative-service/pom.xml
@@ -38,7 +38,7 @@
         <quarkus.platform.version>3.27.3</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+        <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
         <version.compiler.plugin>3.11.0</version.compiler.plugin>
         <maven.compiler.release>17</maven.compiler.release>
         <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-custom-function-knative/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-custom-function-knative/pom.xml
@@ -28,7 +28,7 @@
     <parent>
       <groupId>org.kie.kogito.examples</groupId>
       <artifactId>serverless-workflow-examples-parent</artifactId>
-      <version>111-SNAPSHOIT</version>
+      <version>111-SNAPSHOT</version>
       <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
     </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-custom-function-knative/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-custom-function-knative/pom.xml
@@ -28,7 +28,7 @@
     <parent>
       <groupId>org.kie.kogito.examples</groupId>
       <artifactId>serverless-workflow-examples-parent</artifactId>
-      <version>999-SNAPSHOT</version>
+      <version>111-SNAPSHOIT</version>
       <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
     </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-custom-function-knative/workflow/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-custom-function-knative/workflow/pom.xml
@@ -39,7 +39,7 @@
         <quarkus.platform.version>3.27.3</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+        <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
         <version.compiler.plugin>3.11.0</version.compiler.plugin>
         <maven.compiler.release>17</maven.compiler.release>
         <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-custom-function-knative/workflow/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-custom-function-knative/workflow/pom.xml
@@ -39,7 +39,7 @@
         <quarkus.platform.version>3.27.3</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+        <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
         <version.compiler.plugin>3.11.0</version.compiler.plugin>
         <maven.compiler.release>17</maven.compiler.release>
         <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-custom-type/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -44,7 +44,7 @@
      <quarkus.platform.version>3.27.3</quarkus.platform.version>
      <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
      <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+     <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
      <version.failsafe.plugin>3.3.1</version.failsafe.plugin>
      <maven.compiler.release>17</maven.compiler.release>
      <version.org.slf4j>1.7.30</version.org.slf4j>

--- a/serverless-workflow-examples/serverless-workflow-custom-type/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -44,7 +44,7 @@
      <quarkus.platform.version>3.27.3</quarkus.platform.version>
      <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
      <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-     <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
      <version.failsafe.plugin>3.3.1</version.failsafe.plugin>
      <maven.compiler.release>17</maven.compiler.release>
      <version.org.slf4j>1.7.30</version.org.slf4j>

--- a/serverless-workflow-examples/serverless-workflow-data-index-persistence-addon-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-data-index-persistence-addon-quarkus/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -23,7 +23,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-data-index-persistence-addon-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-data-index-persistence-addon-quarkus/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -23,7 +23,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-data-index-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-data-index-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-data-index-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-data-index-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-dmn-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-dmn-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <maven.compiler.release>17</maven.compiler.release>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-dmn-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-dmn-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <maven.compiler.release>17</maven.compiler.release>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-error-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-error-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <maven.compiler.release>17</maven.compiler.release>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-error-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-error-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <maven.compiler.release>17</maven.compiler.release>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-events-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-events-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,11 +43,11 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
     <version.org.testcontainers>2.0.3</version.org.testcontainers>
   </properties>
 

--- a/serverless-workflow-examples/serverless-workflow-events-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-events-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,11 +43,11 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
     <version.org.testcontainers>2.0.3</version.org.testcontainers>
   </properties>
 

--- a/serverless-workflow-examples/serverless-workflow-examples-parent/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-examples-parent/pom.xml
@@ -26,7 +26,7 @@
 
   <groupId>org.kie.kogito.examples</groupId>
   <artifactId>serverless-workflow-examples-parent</artifactId>
-  <version>999-SNAPSHOT</version>
+  <version>111-SNAPSHOIT</version>
   <packaging>pom</packaging>
   <name>Kogito Example :: Serverless Workflow Examples :: Parent</name>
 
@@ -55,7 +55,7 @@
     <repository>
       <id>central</id>
       <name>Central</name>
-      <url>https://repo1.maven.org/maven2/</url>
+      <url>https://repo.maven.apache.org/maven2/</url>
     </repository>
     <repository>
       <id>github</id>
@@ -77,7 +77,7 @@
     <pluginRepository>
       <id>central</id>
       <name>Central</name>
-      <url>https://repo1.maven.org/maven2/</url>
+      <url>https://repo.maven.apache.org/maven2/</url>
     </pluginRepository>
     <pluginRepository>
       <id>github</id>

--- a/serverless-workflow-examples/serverless-workflow-examples-parent/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-examples-parent/pom.xml
@@ -38,17 +38,63 @@
     <container.image.kafka>redpandadata/redpanda:v24.3.1</container.image.kafka>
   </properties>
 
-  <repositories>
-    <!-- useful to resolve parent pom when it is a SNAPSHOT -->
+  <distributionManagement>
     <repository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/kubesmarts/sonataflow-maven-repository</url>
+    </repository>
+    <snapshotRepository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/kubesmarts/sonataflow-maven-repository</url>
+    </snapshotRepository>
+  </distributionManagement>
+
+  <repositories>
+    <repository>
+      <id>central</id>
+      <name>Central</name>
+      <url>https://repo1.maven.org/maven2/</url>
+    </repository>
+    <repository>
+      <id>github</id>
+      <name>GitHub Repository</name>
+      <url>https://maven.pkg.github.com/kubesmarts/sonataflow-maven-repository</url>
+    </repository>
+    <repository>
+      <id>redhat-ga-repository</id>
+      <url>https://maven.repository.redhat.com/ga</url>
       <releases>
-        <enabled>false</enabled>
+        <enabled>true</enabled>
       </releases>
-      <id>apache.snapshots</id>
-      <name>Apache Snapshot Repository</name>
-      <url>https://repository.apache.org/snapshots</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
     </repository>
   </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>central</id>
+      <name>Central</name>
+      <url>https://repo1.maven.org/maven2/</url>
+    </pluginRepository>
+    <pluginRepository>
+      <id>github</id>
+      <name>GitHub Repository</name>
+      <url>https://maven.pkg.github.com/kubesmarts/sonataflow-maven-repository</url>
+    </pluginRepository>
+    <pluginRepository>
+      <id>redhat-ga-plugin-repository</id>
+      <url>https://maven.repository.redhat.com/ga</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
 
   <build>
     <pluginManagement>

--- a/serverless-workflow-examples/serverless-workflow-examples-parent/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-examples-parent/pom.xml
@@ -26,7 +26,7 @@
 
   <groupId>org.kie.kogito.examples</groupId>
   <artifactId>serverless-workflow-examples-parent</artifactId>
-  <version>111-SNAPSHOIT</version>
+  <version>111-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Kogito Example :: Serverless Workflow Examples :: Parent</name>
 

--- a/serverless-workflow-examples/serverless-workflow-expression-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-expression-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <maven.compiler.release>17</maven.compiler.release>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-expression-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-expression-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <maven.compiler.release>17</maven.compiler.release>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-fault-tolerance/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-fault-tolerance/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.kie.kogito.examples</groupId>
         <artifactId>serverless-workflow-examples-parent</artifactId>
-        <version>111-SNAPSHOIT</version>
+        <version>111-SNAPSHOT</version>
         <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
     </parent>
 
@@ -45,7 +45,7 @@
         <quarkus.platform.version>3.27.3</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+        <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.2</surefire-plugin.version>
     </properties>

--- a/serverless-workflow-examples/serverless-workflow-fault-tolerance/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-fault-tolerance/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.kie.kogito.examples</groupId>
         <artifactId>serverless-workflow-examples-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOIT</version>
         <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
     </parent>
 
@@ -45,7 +45,7 @@
         <quarkus.platform.version>3.27.3</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+        <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.2</surefire-plugin.version>
     </properties>

--- a/serverless-workflow-examples/serverless-workflow-foreach-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-foreach-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <maven.compiler.release>17</maven.compiler.release>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-foreach-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-foreach-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <maven.compiler.release>17</maven.compiler.release>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-functions-events-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-functions-events-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -45,7 +45,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-functions-events-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-functions-events-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -45,7 +45,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-functions-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-functions-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -45,7 +45,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-functions-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-functions-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -45,7 +45,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-funqy/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-funqy/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-funqy/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-funqy/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-funqy/sw-funqy-workflow/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-funqy/sw-funqy-workflow/pom.xml
@@ -37,7 +37,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-funqy/sw-funqy-workflow/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-funqy/sw-funqy-workflow/pom.xml
@@ -37,7 +37,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-greeting-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-greeting-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <maven.compiler.release>17</maven.compiler.release>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-greeting-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-greeting-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <maven.compiler.release>17</maven.compiler.release>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-greeting-rpc-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-greeting-rpc-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-greeting-rpc-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-greeting-rpc-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-greeting-rpc-quarkus/serverless-workflow-greeting-client-rpc-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-greeting-rpc-quarkus/serverless-workflow-greeting-client-rpc-quarkus/pom.xml
@@ -37,7 +37,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-greeting-rpc-quarkus/serverless-workflow-greeting-client-rpc-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-greeting-rpc-quarkus/serverless-workflow-greeting-client-rpc-quarkus/pom.xml
@@ -37,7 +37,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-hello-world/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-hello-world/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -45,8 +45,8 @@
         <quarkus.platform.version>3.27.3</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-        <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+        <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+        <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
         <maven.compiler.release>17</maven.compiler.release>
         <version.compiler.plugin>3.13.0</version.compiler.plugin>
         <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-hello-world/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-hello-world/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -45,8 +45,8 @@
         <quarkus.platform.version>3.27.3</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-        <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+        <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+        <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
         <maven.compiler.release>17</maven.compiler.release>
         <version.compiler.plugin>3.13.0</version.compiler.plugin>
         <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-loanbroker-showcase/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-loanbroker-showcase/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -45,7 +45,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/serverless-workflow-examples/serverless-workflow-loanbroker-showcase/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-loanbroker-showcase/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -45,7 +45,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/serverless-workflow-examples/serverless-workflow-newsletter-subscription/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-newsletter-subscription/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -45,7 +45,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <version.surefire.plugin>3.3.1</version.surefire.plugin>
     <version.org.webjars.bootstrap>5.1.3</version.org.webjars.bootstrap>
     <version.org.webjars.jquery>3.6.0</version.org.webjars.jquery>

--- a/serverless-workflow-examples/serverless-workflow-newsletter-subscription/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-newsletter-subscription/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -45,7 +45,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <version.surefire.plugin>3.3.1</version.surefire.plugin>
     <version.org.webjars.bootstrap>5.1.3</version.org.webjars.bootstrap>
     <version.org.webjars.jquery>3.6.0</version.org.webjars.jquery>

--- a/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/acme-financial-service/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/acme-financial-service/pom.xml
@@ -36,7 +36,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <version.compiler.plugin>3.14.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>3.5.2</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/acme-financial-service/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/acme-financial-service/pom.xml
@@ -36,7 +36,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.14.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>3.5.2</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/currency-exchange-workflow/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/currency-exchange-workflow/pom.xml
@@ -38,7 +38,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <version.compiler.plugin>3.14.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>3.5.2</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/currency-exchange-workflow/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/currency-exchange-workflow/pom.xml
@@ -38,7 +38,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.14.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>3.5.2</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-opentelemetry-jaeger-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-opentelemetry-jaeger-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -44,8 +44,8 @@
     <quarkus.platform.version>3.20.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
     <maven.compiler.release>17</maven.compiler.release>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-opentelemetry-jaeger-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-opentelemetry-jaeger-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -44,8 +44,8 @@
     <quarkus.platform.version>3.20.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-    <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
     <maven.compiler.release>17</maven.compiler.release>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-openvino-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-openvino-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>2.16.12.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <maven.compiler.release>17</maven.compiler.release>
     <version.exec.plugin>1.6.0</version.exec.plugin>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>

--- a/serverless-workflow-examples/serverless-workflow-openvino-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-openvino-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>2.16.12.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <maven.compiler.release>17</maven.compiler.release>
     <version.exec.plugin>1.6.0</version.exec.plugin>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>

--- a/serverless-workflow-examples/serverless-workflow-order-processing/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-order-processing/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -44,7 +44,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <version.org.wiremock>3.13.0</version.org.wiremock>
     <maven.compiler.release>17</maven.compiler.release>

--- a/serverless-workflow-examples/serverless-workflow-order-processing/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-order-processing/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -44,7 +44,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <version.org.wiremock>3.13.0</version.org.wiremock>
     <maven.compiler.release>17</maven.compiler.release>

--- a/serverless-workflow-examples/serverless-workflow-parallel-execution/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-parallel-execution/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -45,8 +45,8 @@
         <quarkus.platform.version>3.27.3</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-        <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+        <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+        <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
         <maven.compiler.release>17</maven.compiler.release>
         <version.compiler.plugin>3.13.0</version.compiler.plugin>
         <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-parallel-execution/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-parallel-execution/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -45,8 +45,8 @@
         <quarkus.platform.version>3.27.3</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-        <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+        <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+        <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
         <maven.compiler.release>17</maven.compiler.release>
         <version.compiler.plugin>3.13.0</version.compiler.plugin>
         <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-python-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-python-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <maven.compiler.release>17</maven.compiler.release>
     <version.exec.plugin>1.6.0</version.exec.plugin>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>

--- a/serverless-workflow-examples/serverless-workflow-python-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-python-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <maven.compiler.release>17</maven.compiler.release>
     <version.exec.plugin>1.6.0</version.exec.plugin>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>

--- a/serverless-workflow-examples/serverless-workflow-qas-service-showcase/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-qas-service-showcase/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-qas-service-showcase/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-qas-service-showcase/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-answer-service/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-answer-service/pom.xml
@@ -37,7 +37,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <version.org.wiremock>3.13.0</version.org.wiremock>
   </properties>
   <dependencyManagement>

--- a/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-answer-service/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-answer-service/pom.xml
@@ -37,7 +37,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <version.org.wiremock>3.13.0</version.org.wiremock>
   </properties>
   <dependencyManagement>

--- a/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-service/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-service/pom.xml
@@ -37,7 +37,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <version.io.quarkiverse.reactivemessaging.http>2.5.0-lts</version.io.quarkiverse.reactivemessaging.http>
     <version.io.cloudevents>2.3.0</version.io.cloudevents>
   </properties>

--- a/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-service/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-service/pom.xml
@@ -37,7 +37,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <version.io.quarkiverse.reactivemessaging.http>2.5.0-lts</version.io.quarkiverse.reactivemessaging.http>
     <version.io.cloudevents>2.3.0</version.io.cloudevents>
   </properties>

--- a/serverless-workflow-examples/serverless-workflow-saga-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-saga-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.org.assertj>3.27.7</version.org.assertj>

--- a/serverless-workflow-examples/serverless-workflow-saga-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-saga-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.org.assertj>3.27.7</version.org.assertj>

--- a/serverless-workflow-examples/serverless-workflow-service-calls-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-service-calls-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-service-calls-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-service-calls-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-stock-profit/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-stock-profit/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -48,7 +48,7 @@
         <quarkus.platform.version>3.27.3</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+        <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
         <version.compiler.plugin>3.13.0</version.compiler.plugin>
         <maven.compiler.release>17</maven.compiler.release>
         <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-stock-profit/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-stock-profit/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -48,7 +48,7 @@
         <quarkus.platform.version>3.27.3</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+        <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
         <version.compiler.plugin>3.13.0</version.compiler.plugin>
         <maven.compiler.release>17</maven.compiler.release>
         <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-subflows-event/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-subflows-event/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -44,8 +44,8 @@
         <quarkus.platform.version>3.20.3</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
-        <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
+        <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
+        <version.org.kie.kogito>111-SNAPSHOT</version.org.kie.kogito>
         <maven.compiler.release>17</maven.compiler.release>
         <version.compiler.plugin>3.13.0</version.compiler.plugin>
         <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-subflows-event/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-subflows-event/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -44,8 +44,8 @@
         <quarkus.platform.version>3.20.3</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-        <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+        <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+        <version.org.kie.kogito>111-SNAPSHOIT</version.org.kie.kogito>
         <maven.compiler.release>17</maven.compiler.release>
         <version.compiler.plugin>3.13.0</version.compiler.plugin>
         <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-full/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-full/pom.xml
@@ -36,7 +36,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-full/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-full/pom.xml
@@ -36,7 +36,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-function/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-function/pom.xml
@@ -36,7 +36,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-function/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-function/pom.xml
@@ -36,7 +36,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-spec/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-spec/pom.xml
@@ -36,7 +36,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-spec/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-spec/pom.xml
@@ -36,7 +36,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow/pom.xml
@@ -36,7 +36,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow/pom.xml
@@ -36,7 +36,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-testing-with-rest-assured/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-testing-with-rest-assured/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -44,7 +44,7 @@
         <quarkus.platform.version>3.27.3</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+        <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
         <maven.compiler.release>17</maven.compiler.release>
         <version.compiler.plugin>3.13.0</version.compiler.plugin>
         <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-testing-with-rest-assured/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-testing-with-rest-assured/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -44,7 +44,7 @@
         <quarkus.platform.version>3.27.3</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+        <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
         <maven.compiler.release>17</maven.compiler.release>
         <version.compiler.plugin>3.13.0</version.compiler.plugin>
         <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-timeouts-showcase-embedded/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-timeouts-showcase-embedded/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <maven.compiler.release>17</maven.compiler.release>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-timeouts-showcase-embedded/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-timeouts-showcase-embedded/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <maven.compiler.release>17</maven.compiler.release>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-timeouts-showcase-extended/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-timeouts-showcase-extended/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <maven.compiler.release>17</maven.compiler.release>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-timeouts-showcase-extended/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-timeouts-showcase-extended/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <maven.compiler.release>17</maven.compiler.release>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-timeouts-showcase-operator-devprofile/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-timeouts-showcase-operator-devprofile/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <maven.compiler.release>17</maven.compiler.release>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-timeouts-showcase-operator-devprofile/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-timeouts-showcase-operator-devprofile/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>3.27.3</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <maven.compiler.release>17</maven.compiler.release>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/sonataflow-fluent/pom.xml
+++ b/serverless-workflow-examples/sonataflow-fluent/pom.xml
@@ -3,14 +3,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOIT</version>
   </parent>
   <artifactId>sonataflow-fluent</artifactId>
   <name>Kogito Example :: SonataFlow :: Java Embedded examples</name>
   <properties>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
     <maven.compiler.release>17</maven.compiler.release>
     <java.module.name>SonataFlowFluent</java.module.name>
   </properties>

--- a/serverless-workflow-examples/sonataflow-fluent/pom.xml
+++ b/serverless-workflow-examples/sonataflow-fluent/pom.xml
@@ -3,14 +3,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples</artifactId>
-    <version>111-SNAPSHOIT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>sonataflow-fluent</artifactId>
   <name>Kogito Example :: SonataFlow :: Java Embedded examples</name>
   <properties>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>111-SNAPSHOIT</kogito.bom.version>
+    <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
     <maven.compiler.release>17</maven.compiler.release>
     <java.module.name>SonataFlowFluent</java.module.name>
   </properties>


### PR DESCRIPTION
Ticket: https://redhat.atlassian.net/browse/SRVLOGIC-963

Had to recreate this PR to get the latest changes from kogito-pipelines in PR checks.

- Updates distributionManagement and repositories section.
- Changes 999-SNAPSHOT to 111-SNAPSHOT to distinct from Apache snapshots.
- Removed modules defined in the productized/modules directory from pom.xmls. (Basically the remove_modules.sh script was executed on this branch).

Related PRs:
https://github.com/kiegroup/drools/pull/182
https://github.com/kiegroup/kogito-runtimes/pull/177
https://github.com/kiegroup/kogito-apps/pull/120
https://github.com/kubesmarts/kie-tools/pull/301