### PR TITLE
[Security] Fix Dependabot alert #93: Update tensorflow to >=2.12.1

### DIFF
--- a/serverless-workflow-examples/serverless-workflow-openvino-quarkus/requirements.txt
+++ b/serverless-workflow-examples/serverless-workflow-openvino-quarkus/requirements.txt
@@ -26,7 +26,7 @@ transformers>=4.21.1
 # jupyter
 jupyterlab
 ipywidgets
-ipykernel>=5.*
+ipykernel>=5.0
 ipython>=7.16.3
 
 

--- a/serverless-workflow-examples/serverless-workflow-openvino-quarkus/requirements.txt
+++ b/serverless-workflow-examples/serverless-workflow-openvino-quarkus/requirements.txt
@@ -13,9 +13,9 @@ onnx>=1.11.0
 
 --find-links https://download.pytorch.org/whl/torch_stable.html
 torch>=1.13.1; sys_platform == 'darwin'
-torch>=1.13.1+cpu; sys_platform == 'linux' or platform_system == 'Windows'
+torch>=1.13.1; sys_platform == 'linux' or platform_system == 'Windows'
 torchvision>=0.14.1; sys_platform == 'darwin'
-torchvision>=0.14.1+cpu; sys_platform == 'linux' or platform_system == 'Windows'
+torchvision>=0.14.1; sys_platform == 'linux' or platform_system == 'Windows'
 
 #paddlepaddle>=2.4.0
 

--- a/serverless-workflow-examples/serverless-workflow-openvino-quarkus/requirements.txt
+++ b/serverless-workflow-examples/serverless-workflow-openvino-quarkus/requirements.txt
@@ -5,9 +5,9 @@ nncf==2.4.0
 
 
 # deep learning frameworks
-tensorflow-macos>=2.5,<=2.12; sys_platform == 'darwin' and platform_machine == 'arm64' # macOS M1 and M2
-tensorflow>=2.5,<=2.12; sys_platform == 'darwin' and platform_machine != 'arm64' # macOS x86
-tensorflow>=2.5,<=2.12; sys_platform == 'linux' or platform_system == 'Windows'
+tensorflow-macos>=2.12.1,<=2.13; sys_platform == 'darwin' and platform_machine == 'arm64' # macOS M1 and M2
+tensorflow>=2.12.1,<=2.13; sys_platform == 'darwin' and platform_machine != 'arm64' # macOS x86
+tensorflow>=2.12.1,<=2.13; sys_platform == 'linux' or platform_system == 'Windows'
 
 onnx>=1.11.0
 


### PR DESCRIPTION
## Security Fix

This PR addresses Dependabot security alert #93 for the `serverless-workflow-openvino-quarkus` project.

### Alert Details
- **Package**: tensorflow
- **Severity**: HIGH
- **CVE**: CVE-2023-33976
- **GHSA**: GHSA-gjh7-xx4r-x345
- **Summary**: TensorFlow has segfault in array_ops.upper_bound
- **Vulnerable Range**: < 2.12.1
- **Patched Version**: 2.12.1

### Changes Made

1. **Security Fix**: Updated tensorflow version constraints from `<=2.12` to `>=2.12.1,<=2.13` in `requirements.txt` (lines 8-10)
   - This ensures all tensorflow installations use version 2.12.1 or higher, which includes the security patch

2. **Syntax Fixes**: Fixed invalid pip requirement syntax in `requirements.txt`:
   - Line 16: Changed `torch>=1.13.1+cpu` to `torch>=1.13.1` (local version identifiers can't be used with `>=`)
   - Line 18: Changed `torchvision>=0.14.1+cpu` to `torchvision>=0.14.1`
   - Line 29: Changed `ipykernel>=5.*` to `ipykernel>=5.0` (wildcard suffix can't be used with `>=`)

### Verification

- ✅ Requirements syntax validated with `pip install --dry-run`
- ✅ All three commits address the security vulnerability and fix pre-existing syntax issues
- ⚠️ Full pip install fails due to matplotlib build dependencies (pre-existing environment issue, unrelated to this security fix)

### Notes

The project has pre-existing build environment issues (matplotlib compilation failures) that prevent full dependency installation. However, the security fix itself is valid and the requirements.txt syntax is now correct.

### Commits
1. Update tensorflow to >=2.12.1 to fix CVE-2023-33976 (GHSA-gjh7-xx4r-x345)
2. Fix torch/torchvision syntax: remove +cpu local version identifier  
3. Fix ipykernel syntax: change >=5.* to >=5.0

---

**Fixes Dependabot Alert**: #93
**Security Advisory**: https://github.com/advisories/GHSA-gjh7-xx4r-x345