### PR TITLE
[Security] Fix Dependabot alerts #46, #99: Update ws to 8.20.1

### DIFF
--- a/serverless-workflow-examples/serverless-workflow-loanbroker-showcase/loanbroker-js/package.json
+++ b/serverless-workflow-examples/serverless-workflow-loanbroker-showcase/loanbroker-js/package.json
@@ -20,7 +20,7 @@
     "recoil": "^0.7.5",
     "sass": "^1.54.7",
     "socket.io-client": "^4.5.2",
-    "ws": "^8.17.1"
+    "ws": "^8.20.1"
   },
   "devDependencies": {
     "@types/node": "18.7.14",

--- a/serverless-workflow-examples/serverless-workflow-loanbroker-showcase/loanbroker-js/yarn.lock
+++ b/serverless-workflow-examples/serverless-workflow-loanbroker-showcase/loanbroker-js/yarn.lock
@@ -2357,7 +2357,7 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@^8.17.1:
+ws@^8.20.1:
   version "8.21.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
   integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==


### PR DESCRIPTION
## 🔒 Security Fix: Update ws to 8.20.1

### Summary
Fixes Dependabot security alerts #46, #99 by updating ws from 8.17.1 to 8.20.1.

### Security Issue
- **Alert #46 (HIGH)**: CVE-2024-37890 / GHSA-3h5v-q93c-6h6q - ws affected by DoS when handling a request with many HTTP headers
- **Alert #99 (MEDIUM)**: CVE-2026-45736 / GHSA-58qx-3vcg-4xpx - ws: Uninitialized memory disclosure

### Changes
- Updated `ws` from `^8.17.1` to `^8.20.1` in `serverless-workflow-examples/serverless-workflow-loanbroker-showcase/loanbroker-js/package.json`
- Updated yarn.lock

### Verification
- ✅ Build successful (Next.js production build completed)
- ✅ No test failures (no test script defined for this package)

---
🤖 **Automated fix by [Dependabot Auto-Fix Skill](https://github.com/baldimir/ai-tools/tree/main/skills/dependabot-autofix)**