### PR TITLE
[Fix 2351] Use mirrored PostgreSQL image in PostgresTestResource to avoid Docker Hub pull rate limits

### DIFF
--- a/serverless-workflow-examples/serverless-workflow-opentelemetry-jaeger-quarkus/src/test/java/org/kie/kogito/examples/sw/opentelemetry/jaeger/persistence/PostgresTestResource.java
+++ b/serverless-workflow-examples/serverless-workflow-opentelemetry-jaeger-quarkus/src/test/java/org/kie/kogito/examples/sw/opentelemetry/jaeger/persistence/PostgresTestResource.java
@@ -27,13 +27,18 @@ import org.testcontainers.containers.PostgreSQLContainer;
 
 public class PostgresTestResource implements QuarkusTestResourceLifecycleManager {
 
-    private static final String IMAGE = "postgres:16-alpine";
+    private static final String IMAGE = System.getProperty(
+            "postgres.image",
+            "mirror.gcr.io/postgres:17-alpine");
+
     private PostgreSQLContainer<?> postgres;
 
     @Override
     public Map<String, String> start() {
-        postgres = new PostgreSQLContainer<>(IMAGE).withDatabaseName("kogito").withUsername("kogito")
+        DockerImageName imageName = DockerImageName.parse(IMAGE).asCompatibleSubstituteFor("postgres");
+        postgres = new PostgreSQLContainer<>(imageName).withDatabaseName("kogito").withUsername("kogito")
                 .withPassword("kogito");
+        
         postgres.start();
 
         Map<String, String> props = new HashMap<>();


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/2351
