### PR TITLE
[SRVLOGIC-1086] Update Quarkus to 3.27.4.1.

### DIFF
--- a/serverless-workflow-examples/serverless-workflow-annotations-description/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-annotations-description/pom.xml
@@ -38,10 +38,10 @@
     <name>Kogito Example :: Serverless Workflow Annotations and Description:: Quarkus</name>
     <description>Kogito Serverless Workflow Example - Quarkus</description>
     <properties>
-        <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+        <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.27.4</quarkus.platform.version>
+        <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
         <version.org.assertj>3.27.7</version.org.assertj>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>

--- a/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/callback-event-service/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/callback-event-service/pom.xml
@@ -32,10 +32,10 @@
     <artifactId>callback-event-service</artifactId>
     <name>Kogito Example :: Serverless Workflow CallBack Over HTTP Quarkus :: Callback Event Service</name>
     <properties>
-        <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+        <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.27.4</quarkus.platform.version>
+        <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
         <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/callback-workflow/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/callback-workflow/pom.xml
@@ -33,10 +33,10 @@
     <name>Kogito Example :: Serverless Workflow CallBack Over HTTP Quarkus :: Service</name>
     <description>Kogito Serverless Workflow Callback Example Over HTTP - Quarkus</description>
     <properties>
-        <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+        <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.27.4</quarkus.platform.version>
+        <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
         <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-callback-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-callback-quarkus/pom.xml
@@ -37,10 +37,10 @@
   <name>Kogito Example :: Serverless Workflow Callback :: Quarkus</name>
   <description>Kogito Serverless Workflow Callback Example - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-camel-routes/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-camel-routes/pom.xml
@@ -39,10 +39,10 @@
   <description>Kogito Serverless Workflow Camel Routes Example - Quarkus</description>
 
   <properties>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
@@ -52,7 +52,7 @@
     <!-- Used by the WSDL plugin -->
     <version.org.apache.cxf>3.5.4</version.org.apache.cxf>
     <!-- Aligned with Quarkus. We don't use the Camel Quarkus platform BOM to avoid upgrade delays in our CI. Feel free to use the BOM in your projects, though -->
-    <version.org.apache.camel.quarkus>3.27.4</version.org.apache.camel.quarkus>
+    <version.org.apache.camel.quarkus>3.27.4.1</version.org.apache.camel.quarkus>
   </properties>
 
   <dependencyManagement>

--- a/serverless-workflow-examples/serverless-workflow-camel-routes/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-camel-routes/pom.xml
@@ -52,7 +52,7 @@
     <!-- Used by the WSDL plugin -->
     <version.org.apache.cxf>3.5.4</version.org.apache.cxf>
     <!-- Aligned with Quarkus. We don't use the Camel Quarkus platform BOM to avoid upgrade delays in our CI. Feel free to use the BOM in your projects, though -->
-    <version.org.apache.camel.quarkus>3.27.4.1</version.org.apache.camel.quarkus>
+    <version.org.apache.camel.quarkus>3.27.4</version.org.apache.camel.quarkus>
   </properties>
 
   <dependencyManagement>

--- a/serverless-workflow-examples/serverless-workflow-compensation-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-compensation-quarkus/pom.xml
@@ -37,10 +37,10 @@
   <name>Kogito Example :: Serverless Workflow Compensation :: Quarkus</name>
   <description>Kogito Serverless Workflow Error Compensation - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-consuming-events-over-http-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-consuming-events-over-http-quarkus/pom.xml
@@ -39,10 +39,10 @@
     <name>Kogito Example :: Serverless Workflow Consuming Events Over HTTP :: Quarkus</name>
     <description>Kogito Serverless Workflow Consuming Events Over HTTP - Quarkus</description>
     <properties>
-        <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+        <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.27.4</quarkus.platform.version>
+        <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
         <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-correlation-quarkus-mongodb/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-correlation-quarkus-mongodb/pom.xml
@@ -37,10 +37,10 @@
   <name>Kogito Example :: Serverless Workflow Correlation :: Quarkus :: MongoDB</name>
   <description>Kogito Serverless Workflow Correlation Example - Quarkus - MongoDB</description>
   <properties>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-correlation-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-correlation-quarkus/pom.xml
@@ -37,10 +37,10 @@
   <name>Kogito Example :: Serverless Workflow Correlation :: Quarkus</name>
   <description>Kogito Serverless Workflow Correlation Example - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-custom-function-knative/custom-function-knative-service/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-custom-function-knative/custom-function-knative-service/pom.xml
@@ -32,10 +32,10 @@
     <artifactId>custom-function-knative-service</artifactId>
     <name>Kogito Example :: Serverless Workflow Custom Function Knative :: Service</name>
     <properties>
-        <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+        <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.27.4</quarkus.platform.version>
+        <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
         <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-custom-function-knative/workflow/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-custom-function-knative/workflow/pom.xml
@@ -33,10 +33,10 @@
     <name>Kogito Example :: Serverless Workflow Custom Function Knative :: Workflow</name>
     <description>Kogito Serverless Workflow Custom Function Knative - Workflow</description>
     <properties>
-        <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+        <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.27.4</quarkus.platform.version>
+        <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
         <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-custom-type/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/pom.xml
@@ -38,10 +38,10 @@
   
   <properties>
      <version.compiler.plugin>3.13.0</version.compiler.plugin>
-     <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+     <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
      <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
      <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-     <quarkus.platform.version>3.27.4</quarkus.platform.version>
+     <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
      <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
      <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
      <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-data-index-persistence-addon-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-data-index-persistence-addon-quarkus/pom.xml
@@ -17,10 +17,10 @@
   <name>Kogito Example :: Serverless Workflow Data Index persistence addon :: Quarkus</name>
   <description>Kogito Serverless Workflow Data Index persistence addon Example - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-data-index-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-data-index-quarkus/pom.xml
@@ -37,10 +37,10 @@
   <name>Kogito Example :: Serverless Workflow Data Index :: Quarkus</name>
   <description>Kogito Serverless Workflow Data Index Example - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-dmn-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-dmn-quarkus/pom.xml
@@ -37,10 +37,10 @@
   <name>Kogito Example :: Serverless Workflow :: DMN:: Quarkus</name>
   <description>Kogito Serverless Workflow DMN Example - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-error-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-error-quarkus/pom.xml
@@ -37,10 +37,10 @@
   <name>Kogito Example :: Serverless Workflow Error :: Quarkus</name>
   <description>Kogito Serverless Workflow Error Example - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-events-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-events-quarkus/pom.xml
@@ -37,10 +37,10 @@
   <name>Kogito Example :: Serverless Workflow Events :: Quarkus</name>
   <description>Kogito Serverless Workflow Example - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-expression-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-expression-quarkus/pom.xml
@@ -37,10 +37,10 @@
   <name>Kogito Example :: Serverless Workflow Expression :: Quarkus</name>
   <description>Kogito Serverless Workflow Expression Example - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-fault-tolerance/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-fault-tolerance/pom.xml
@@ -42,7 +42,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.27.4</quarkus.platform.version>
+        <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
         <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-foreach-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-foreach-quarkus/pom.xml
@@ -37,10 +37,10 @@
   <name>Kogito Example :: Serverless Workflow For Each :: Quarkus</name>
   <description>Kogito Serverless Workflow For Each Example - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-functions-events-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-functions-events-quarkus/pom.xml
@@ -39,10 +39,10 @@
   <properties>
     <!-- fixed port for tests, see https://issues.redhat.com/browse/KOGITO-6406 -->
     <tests.quarkus.http.port>8080</tests.quarkus.http.port>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-functions-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-functions-quarkus/pom.xml
@@ -39,10 +39,10 @@
   <properties>
     <!-- fixed port for tests, see https://issues.redhat.com/browse/KOGITO-6406 -->
     <tests.quarkus.http.port>8080</tests.quarkus.http.port>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-funqy/sw-funqy-services/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-funqy/sw-funqy-services/pom.xml
@@ -31,10 +31,10 @@
   <name>Kogito Example :: Serverless Workflow :: Funqy :: Services</name>
   <description>Kogito Serverless Workflow Funqy Services - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-funqy/sw-funqy-workflow/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-funqy/sw-funqy-workflow/pom.xml
@@ -31,10 +31,10 @@
   <name>Kogito Example :: Serverless Workflow :: Funqy :: Workflow</name>
   <description>Kogito Serverless Workflow Funqy Workflow - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-greeting-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-greeting-quarkus/pom.xml
@@ -37,10 +37,10 @@
   <name>Kogito Example :: Serverless Workflow Greeting :: Quarkus</name>
   <description>Kogito Serverless Workflow Example - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-greeting-rpc-quarkus/serverless-workflow-greeting-client-rpc-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-greeting-rpc-quarkus/serverless-workflow-greeting-client-rpc-quarkus/pom.xml
@@ -31,10 +31,10 @@
   <name>Kogito Example :: Serverless Workflow Greeting :: gRPC Client :: Quarkus</name>
   <description>Kogito Serverless Workflow Example that test a simple gRPC service - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-greeting-rpc-quarkus/serverless-workflow-greeting-server-rpc-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-greeting-rpc-quarkus/serverless-workflow-greeting-server-rpc-quarkus/pom.xml
@@ -36,7 +36,7 @@
         <maven.compiler.release>17</maven.compiler.release>
         <version.surefire.plugin>3.3.1</version.surefire.plugin>
         <version.com.google.protobuf>3.22.0</version.com.google.protobuf>
-        <version.io.grpc>1.75.0</version.io.grpc>
+        <version.io.grpc>1.82.2</version.io.grpc>
         <version.kr.motd.maven.os>1.6.0</version.kr.motd.maven.os>
         <version.org.xolstice.maven.protobuf>0.6.1</version.org.xolstice.maven.protobuf>
         <version.jib-maven-plugin>3.3.0</version.jib-maven-plugin>

--- a/serverless-workflow-examples/serverless-workflow-hello-world/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-hello-world/pom.xml
@@ -39,10 +39,10 @@
     <description>Kogito Serverless Workflow Example - Quarkus</description>
 
     <properties>
-        <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+        <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.27.4</quarkus.platform.version>
+        <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
         <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-loanbroker-showcase/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-loanbroker-showcase/pom.xml
@@ -55,7 +55,7 @@
     <version.io.cloudevents>2.5.0</version.io.cloudevents>
     <!-- See: https://camel.apache.org/categories/Camel-Quarkus/ -->
     <!-- Aligned with Quarkus. We don't use the Camel Quarkus platform BOM to avoid upgrade delays in our CI. Feel free to use the BOM in your projects, though -->
-    <version.org.apache.camel.quarkus>3.27.4.1</version.org.apache.camel.quarkus>
+    <version.org.apache.camel.quarkus>3.27.4</version.org.apache.camel.quarkus>
 
     <version.surefire.plugin>3.3.1</version.surefire.plugin>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>

--- a/serverless-workflow-examples/serverless-workflow-loanbroker-showcase/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-loanbroker-showcase/pom.xml
@@ -39,10 +39,10 @@
   <artifactId>serverless-workflow-loanbroker-showcase</artifactId>
   <packaging>pom</packaging>
   <properties>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>
@@ -55,7 +55,7 @@
     <version.io.cloudevents>2.5.0</version.io.cloudevents>
     <!-- See: https://camel.apache.org/categories/Camel-Quarkus/ -->
     <!-- Aligned with Quarkus. We don't use the Camel Quarkus platform BOM to avoid upgrade delays in our CI. Feel free to use the BOM in your projects, though -->
-    <version.org.apache.camel.quarkus>3.27.4</version.org.apache.camel.quarkus>
+    <version.org.apache.camel.quarkus>3.27.4.1</version.org.apache.camel.quarkus>
 
     <version.surefire.plugin>3.3.1</version.surefire.plugin>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>

--- a/serverless-workflow-examples/serverless-workflow-newsletter-subscription/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-newsletter-subscription/pom.xml
@@ -39,10 +39,10 @@
   <artifactId>serverless-workflow-newsletter-subscription</artifactId>
   <packaging>pom</packaging>
   <properties>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/acme-financial-service/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/acme-financial-service/pom.xml
@@ -30,10 +30,10 @@
   <artifactId>acme-financial-service</artifactId>
   <name>Kogito Example :: Serverless Workflow Oauth2 Orchestration Example :: ACME Financial Service</name>
   <properties>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/currency-exchange-workflow/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/currency-exchange-workflow/pom.xml
@@ -32,10 +32,10 @@
   <name>Kogito Example :: Serverless Workflow Oauth2 Orchestration Example :: Currency Exchange</name>
 
   <properties>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-order-processing/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-order-processing/pom.xml
@@ -38,10 +38,10 @@
 
   <name>Kogito Example :: Serverless Workflow Order Processing</name>
   <properties>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-parallel-execution/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-parallel-execution/pom.xml
@@ -39,10 +39,10 @@
     <description>Kogito Serverless Workflow Example - Quarkus</description>
 
     <properties>
-        <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+        <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.27.4</quarkus.platform.version>
+        <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
         <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-python-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-python-quarkus/pom.xml
@@ -37,10 +37,10 @@
   <name>Kogito Example :: Serverless Workflow Python :: Quarkus</name>
   <description>Kogito Serverless Workflow Python Example - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-answer-service/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-answer-service/pom.xml
@@ -31,10 +31,10 @@
   <artifactId>query-answer-service</artifactId>
   <name>Kogito Example :: Serverless Workflow Query and Answer :: Workflow Service</name>
   <properties>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-service/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-service/pom.xml
@@ -31,10 +31,10 @@
   <artifactId>query-service</artifactId>
   <name>Kogito Example :: Serverless Workflow Query and Answer :: Query Service</name>
   <properties>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>    
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-saga-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-saga-quarkus/pom.xml
@@ -37,10 +37,10 @@
   <description>How to implement Saga with a Serverless Workflow</description>
 
   <properties>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-service-calls-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-service-calls-quarkus/pom.xml
@@ -37,10 +37,10 @@
   <name>Kogito Example :: Serverless Workflow Service Calls :: Quarkus</name>
   <description>Kogito Serverless Workflow Example - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-stock-profit/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-stock-profit/pom.xml
@@ -42,10 +42,10 @@
         <module>fake-stock-service</module>
     </modules>
     <properties>
-        <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+        <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.27.4</quarkus.platform.version>
+        <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
         <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-full/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-full/pom.xml
@@ -30,10 +30,10 @@
   <artifactId>conversion-workflow-full</artifactId>
   <name>Kogito Example :: Serverless Workflow Temperature Conversion :: Conversion Full Service</name>
   <properties>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-function/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-function/pom.xml
@@ -30,10 +30,10 @@
   <artifactId>conversion-workflow-function</artifactId>
   <name>Kogito Example :: Serverless Workflow Temperature Conversion :: Conversion Function Service</name>
   <properties>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-spec/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-spec/pom.xml
@@ -30,10 +30,10 @@
   <artifactId>conversion-workflow-spec</artifactId>
   <name>Kogito Example :: Serverless Workflow Temperature Conversion :: Conversion Spec Service</name>
   <properties>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow/pom.xml
@@ -30,10 +30,10 @@
   <artifactId>conversion-workflow</artifactId>
   <name>Kogito Example :: Serverless Workflow Temperature Conversion :: Conversion Service</name>
   <properties>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/multiplication-service/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/multiplication-service/pom.xml
@@ -30,10 +30,10 @@
   <artifactId>multiplication-service</artifactId>
   <name>Kogito Example :: Serverless Workflow Temperature Conversion :: Multiplication Service</name>
   <properties>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/subtraction-service/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/subtraction-service/pom.xml
@@ -30,10 +30,10 @@
   <artifactId>subtraction-service</artifactId>
   <name>Kogito Example :: Serverless Workflow Temperature Conversion :: Subtraction Service</name>
   <properties>
-    <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.surefire.plugin>3.3.1</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-testing-with-rest-assured/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-testing-with-rest-assured/pom.xml
@@ -38,10 +38,10 @@
     <name>Kogito Example :: Serverless Workflow Testing with REST Assured :: Quarkus</name>
     <description>Kogito Serverless Workflow Example - Quarkus</description>
     <properties>
-        <quarkus-plugin.version>3.27.4</quarkus-plugin.version>
+        <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.27.4</quarkus.platform.version>
+        <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
         <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-timeouts-showcase-embedded/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-timeouts-showcase-embedded/pom.xml
@@ -40,7 +40,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-timeouts-showcase-extended/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-timeouts-showcase-extended/pom.xml
@@ -40,7 +40,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>

--- a/serverless-workflow-examples/serverless-workflow-timeouts-showcase-operator-devprofile/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-timeouts-showcase-operator-devprofile/pom.xml
@@ -40,7 +40,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.4</quarkus.platform.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>111-SNAPSHOT</kogito.bom.version>


### PR DESCRIPTION
Ticket: https://redhat.atlassian.net/browse/SRVLOGIC-1086

Updates Quarkus to 3.27.4.1 and aligns other dependencies with the changes in the new Quarkus version.